### PR TITLE
Upgrade buildimage

### DIFF
--- a/code-build.tf
+++ b/code-build.tf
@@ -22,7 +22,7 @@ resource "aws_codebuild_project" "tflint" {
 
   environment {
     compute_type = "BUILD_GENERAL1_SMALL"
-    image        = "aws/codebuild/standard:5.0"
+    image        = "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
     type         = "LINUX_CONTAINER"
   }
 
@@ -51,7 +51,7 @@ resource "aws_codebuild_project" "checkov" {
 
   environment {
     compute_type = "BUILD_GENERAL1_SMALL"
-    image        = "aws/codebuild/standard:5.0"
+    image        = "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
     type         = "LINUX_CONTAINER"
   }
 
@@ -80,7 +80,7 @@ resource "aws_codebuild_project" "tf_plan" {
 
   environment {
     compute_type = "BUILD_GENERAL1_SMALL"
-    image        = "aws/codebuild/standard:5.0"
+    image        = "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
     type         = "LINUX_CONTAINER"
     environment_variable {
       name  = "VAR_FILE"
@@ -113,7 +113,7 @@ resource "aws_codebuild_project" "tf_apply" {
 
   environment {
     compute_type = "BUILD_GENERAL1_SMALL"
-    image        = "aws/codebuild/standard:5.0"
+    image        = "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
     type         = "LINUX_CONTAINER"
     environment_variable {
       name  = "VAR_FILE"


### PR DESCRIPTION
Starting March 30, 2023, AWS CodeBuild will be moving these images to an unsupported status and they will not be cached on the build hosts anymore.

You may continue using these images for your builds, but you will notice an increase in provisioning latency after March 30, 2023.
These images will also not be getting any new updates. We recommend updating your Build Projects to use the latest build images in order to get the latest language runtimes and tools

-->

Ubuntu standard 5.0 -> Amazon Linux 2 standard 4.0 