### PR TITLE
Support for custom .tfbackend -file

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ data "aws_dynamodb_table" "tf_state" {
 | aws_region | AWS region to deploy pipeline to | string | `eu-central-1` |  |
 | require_manual_approval | Whether or not a manual approval of changes is required before applying changes | bool | true |  |
 | variables_file | File to provide terraform the variables with | string | "" | If not given, will automatically try to use `environments/{environment}.tfvars` |
+| tfbackend_file | File to provide terraform the backend config with | string | "" | Naming convension: {environment}.s3.tfbackend, see [HashiCorp documentation](https://developer.hashicorp.com/terraform/language/settings/backends/configuration#using-a-backend-block) |
 | tags | Map of Tag-Value -pairs to be added to all resources | map |  | `{ Tag: "Value", Cool: true }` |
 | managed_policies | List of AWS managed Policies to attach to pipeline | list(string) |  | example ['AmazonRDSFullAccess'] |
 | emails | List of email-addresses receiving notifications on updates | list(string) | [] | All recipient will receive confirmation email from AWS |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ data "aws_dynamodb_table" "tf_state" {
 }
 ```
 
-- Pipeline with manual approval, failure and success reporting, custom variables file, custom branch-name
+- Pipeline with manual approval, failure and success reporting, custom variables file, .tfbackend-file, custom branch-name
 ```
 module "tf_infra_pipeline" {
   source                = "git::https://github.com/Nets-Platform-Enablement/tf-module-aws-infra-pipeline?ref=v1.2.4"
@@ -29,6 +29,7 @@ module "tf_infra_pipeline" {
   require_manual_approval = true
   tf_state_dynamodb_arn = data.aws_dynamodb_table.tf_state.arn
   variables_file        = "environment/prod.tfvars"
+  tfbackend_file        = "environment/prod.s3.tfbackend"
   emails                = [ "first.last@nexigroup.com", "jane.doe@nexigroup.com" ]
   failure_notifications = "ENABLED"
   success_notifications = "ENABLED"

--- a/code-build.tf
+++ b/code-build.tf
@@ -32,7 +32,8 @@ resource "aws_codebuild_project" "tflint" {
       "${path.module}/files/buildspec_tflint.yml.tftpl",
       {
         TF_VERSION = local.terraform_version,
-        DIRECTORY  = var.directory
+        DIRECTORY  = var.directory,
+        BACKENDFILE = var.tfbackend_file
       }
     )
   }
@@ -65,7 +66,8 @@ resource "aws_codebuild_project" "tf_plan" {
       {
         TF_VERSION  = local.terraform_version,
         DIRECTORY   = var.directory,
-        EXTRA_FILES = var.extra_build_artifacts
+        EXTRA_FILES = var.extra_build_artifacts,
+        BACKENDFILE = var.tfbackend_file
       }
     )
   }
@@ -97,7 +99,8 @@ resource "aws_codebuild_project" "tf_apply" {
       "${path.module}/files/${var.require_manual_approval ? "buildspec_tf_apply.yml.tftpl" : "buildspec_tf_apply_auto_approve.yml.tftpl"}",
       {
         TF_VERSION = local.terraform_version,
-        DIRECTORY  = var.directory
+        DIRECTORY  = var.directory,
+        BACKENDFILE = var.tfbackend_file
       }
     )
   }

--- a/files/buildspec_tf_apply.yml.tftpl
+++ b/files/buildspec_tf_apply.yml.tftpl
@@ -11,7 +11,7 @@ phases:
   build:
     commands:
       - cd "$CODEBUILD_SRC_DIR/${DIRECTORY}"
-      - terraform init -upgrade -no-color
+      - terraform init %{ if BACKENDFILE != "" } -backend-config $BACKENDFILE %{ endif } -upgrade -no-color
       - mv $CODEBUILD_SRC_DIR_TerraformPlan/* .
       - terraform apply thePlan.tfp
 

--- a/files/buildspec_tf_apply.yml.tftpl
+++ b/files/buildspec_tf_apply.yml.tftpl
@@ -11,7 +11,7 @@ phases:
   build:
     commands:
       - cd "$CODEBUILD_SRC_DIR/${DIRECTORY}"
-      - terraform init %{ if BACKENDFILE != "" } -backend-config $BACKENDFILE %{ endif } -upgrade -no-color
+      - terraform init %{ if BACKENDFILE != "" } -backend-config ${BACKENDFILE} %{ endif } -upgrade -no-color
       - mv $CODEBUILD_SRC_DIR_TerraformPlan/* .
       - terraform apply thePlan.tfp
 

--- a/files/buildspec_tf_apply_auto_approve.yml.tftpl
+++ b/files/buildspec_tf_apply_auto_approve.yml.tftpl
@@ -11,7 +11,7 @@ phases:
   build:
     commands:
       - cd "$CODEBUILD_SRC_DIR/${DIRECTORY}"
-      - terraform init %{ if BACKENDFILE != "" } -backend-config $BACKENDFILE %{ endif } -upgrade -no-color
+      - terraform init %{ if BACKENDFILE != "" } -backend-config ${BACKENDFILE} %{ endif } -upgrade -no-color
       - terraform plan --var-file $VAR_FILE -out /tmp/updates.tfp -no-color
       - terraform apply /tmp/updates.tfp -no-color
 

--- a/files/buildspec_tf_apply_auto_approve.yml.tftpl
+++ b/files/buildspec_tf_apply_auto_approve.yml.tftpl
@@ -11,7 +11,7 @@ phases:
   build:
     commands:
       - cd "$CODEBUILD_SRC_DIR/${DIRECTORY}"
-      - terraform init -upgrade -no-color
+      - terraform init %{ if BACKENDFILE != "" } -backend-config $BACKENDFILE %{ endif } -upgrade -no-color
       - terraform plan --var-file $VAR_FILE -out /tmp/updates.tfp -no-color
       - terraform apply /tmp/updates.tfp -no-color
 

--- a/files/buildspec_tf_plan.yml.tftpl
+++ b/files/buildspec_tf_plan.yml.tftpl
@@ -11,7 +11,7 @@ phases:
   build:
     commands:
       - cd "$CODEBUILD_SRC_DIR/${DIRECTORY}"
-      - terraform init %{ if BACKENDFILE != "" } -backend-config $BACKENDFILE %{ endif } -upgrade -no-color
+      - terraform init %{ if BACKENDFILE != "" } -backend-config ${BACKENDFILE} %{ endif } -upgrade -no-color
       - terraform validate
       #- echo "Current Terraform State on `date`"
       #- terraform show

--- a/files/buildspec_tf_plan.yml.tftpl
+++ b/files/buildspec_tf_plan.yml.tftpl
@@ -11,7 +11,7 @@ phases:
   build:
     commands:
       - cd "$CODEBUILD_SRC_DIR/${DIRECTORY}"
-      - terraform init -upgrade -no-color
+      - terraform init %{ if BACKENDFILE != "" } -backend-config $BACKENDFILE %{ endif } -upgrade -no-color
       - terraform validate
       #- echo "Current Terraform State on `date`"
       #- terraform show

--- a/files/buildspec_tflint.yml.tftpl
+++ b/files/buildspec_tflint.yml.tftpl
@@ -12,7 +12,7 @@ phases:
   build:
     commands:   
       - cd "$CODEBUILD_SRC_DIR/${DIRECTORY}"
-      - terraform init -upgrade -no-color
+      - terraform init %{ if BACKENDFILE != "" } -backend-config $BACKENDFILE %{ endif } -upgrade -no-color
       - terraform validate
       - tflint --init
       - tflint

--- a/files/buildspec_tflint.yml.tftpl
+++ b/files/buildspec_tflint.yml.tftpl
@@ -12,7 +12,7 @@ phases:
   build:
     commands:   
       - cd "$CODEBUILD_SRC_DIR/${DIRECTORY}"
-      - terraform init %{ if BACKENDFILE != "" } -backend-config $BACKENDFILE %{ endif } -upgrade -no-color
+      - terraform init %{ if BACKENDFILE != "" } -backend-config ${BACKENDFILE} %{ endif } -upgrade -no-color
       - terraform validate
       - tflint --init
       - tflint

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,13 @@ variable "variables_file" {
   sensitive   = false
 }
 
+variable "tfbackend_file" {
+  type        = string
+  description = "File to provide terraform the backend config with 'terraform init -backend-config {tfbackend_file}'"
+  default     = ""
+  sensitive   = false
+}
+
 variable "tags" {
   type        = map(any)
   description = "Map of Tag-Value -pairs to be added to all resources"


### PR DESCRIPTION
If the project uses .tfbackend -files to separate different environments, the terraform-pipeline also needs a mechanism to use them.