### PR TITLE
Feat/permission overhault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+.terraform.lock.hcl

--- a/code-build.tf
+++ b/code-build.tf
@@ -37,6 +37,13 @@ resource "aws_codebuild_project" "tflint" {
       }
     )
   }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = aws_cloudwatch_log_group.codebuild_log_group.name
+      #stream_name = "log-stream"
+    }
+  }
 }
 
 #Do show and plan for dry run Terraform
@@ -71,6 +78,13 @@ resource "aws_codebuild_project" "tf_plan" {
       }
     )
   }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = aws_cloudwatch_log_group.codebuild_log_group.name
+      #stream_name = "log-stream"
+    }
+  }
 }
 
 resource "aws_codebuild_project" "tf_apply" {
@@ -103,5 +117,12 @@ resource "aws_codebuild_project" "tf_apply" {
         BACKENDFILE = var.tfbackend_file
       }
     )
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = aws_cloudwatch_log_group.codebuild_log_group.name
+      #stream_name = "log-stream"
+    }
   }
 }

--- a/code-build.tf
+++ b/code-build.tf
@@ -1,15 +1,5 @@
 # CodeBuild
 
-#CloudWatch to log files
-resource "aws_cloudwatch_log_group" "codebuild_log_group" {
-  name = "${local.name}-logs"
-
-  tags = merge(local.tags,
-    {
-      Application = local.name
-  })
-  retention_in_days = 7
-}
 #Validate terraform
 resource "aws_codebuild_project" "tflint" {
   name         = "${local.name}-tflint"
@@ -36,13 +26,6 @@ resource "aws_codebuild_project" "tflint" {
         BACKENDFILE = var.tfbackend_file
       }
     )
-  }
-
-  logs_config {
-    cloudwatch_logs {
-      group_name  = aws_cloudwatch_log_group.codebuild_log_group.name
-      #stream_name = "log-stream"
-    }
   }
 }
 
@@ -78,13 +61,6 @@ resource "aws_codebuild_project" "tf_plan" {
       }
     )
   }
-
-  logs_config {
-    cloudwatch_logs {
-      group_name  = aws_cloudwatch_log_group.codebuild_log_group.name
-      #stream_name = "log-stream"
-    }
-  }
 }
 
 resource "aws_codebuild_project" "tf_apply" {
@@ -117,12 +93,5 @@ resource "aws_codebuild_project" "tf_apply" {
         BACKENDFILE = var.tfbackend_file
       }
     )
-  }
-
-  logs_config {
-    cloudwatch_logs {
-      group_name  = aws_cloudwatch_log_group.codebuild_log_group.name
-      #stream_name = "log-stream"
-    }
   }
 }

--- a/code-pipeline-auto-approve.tf
+++ b/code-pipeline-auto-approve.tf
@@ -7,6 +7,10 @@ resource "aws_codepipeline" "terraform_without_approval" {
   artifact_store {
     location = aws_s3_bucket.codepipeline_artifacts_store.bucket
     type     = "S3"
+    encryption_key {
+      type  = "KMS"
+      id    = aws_kms_key.codeartifact_key.key_id
+    }
   }
   stage {
     name = "Clone"

--- a/code-pipeline-manual-approval.tf
+++ b/code-pipeline-manual-approval.tf
@@ -13,6 +13,10 @@ resource "aws_codepipeline" "terraform" {
   artifact_store {
     location = aws_s3_bucket.codepipeline_artifacts_store.bucket
     type     = "S3"
+    encryption_key {
+      type  = "KMS"
+      id    = aws_kms_key.codeartifact_key.key_id
+    }
   }
   stage {
     name = "Clone"

--- a/code-pipeline-manual-approval.tf
+++ b/code-pipeline-manual-approval.tf
@@ -101,9 +101,4 @@ resource "aws_codepipeline" "terraform" {
       }
     }
   }
-  artifact_store {
-    encryption_key {
-      id = "aws_kms_key.codebuild_key.key_id"
-    }
-  }
 }

--- a/code-pipeline-manual-approval.tf
+++ b/code-pipeline-manual-approval.tf
@@ -73,7 +73,7 @@ resource "aws_codepipeline" "terraform" {
       version   = "1"
 
       configuration = {
-        NotificationArn    = module.sns_topic.sns_topic_arn
+        NotificationArn    = module.sns_topic.topic_arn
         CustomData         = "This will deploy following ${local.name} IAC code changes into the ${var.environment} AWS environment"
         ExternalEntityLink = "https://${var.aws_region}.console.aws.amazon.com/cloudwatch/home?region=${var.aws_region}#logsV2:log-groups/log-group/$252Faws$252Fcodebuild$252F${local.name}-tf-plan"
       }

--- a/iam.tf
+++ b/iam.tf
@@ -238,7 +238,7 @@ resource "aws_iam_role_policy" "codebuild" {
 
 # User defined IAM policy for CodeBuild role
 resource "aws_iam_role_policy" "codebuild_additionals" {
-  count = contains(keys(var.role_policy), "statement") ? 1 : 0 # Do not add if role_policy is not given
+  count = contains(keys(var.role_policy), "Statement") ? 1 : 0 # Do not add if role_policy is not given
   name = "CodebuildRolePolicy-${local.name}-additional"
   role = aws_iam_role.codebuild.id
 

--- a/iam.tf
+++ b/iam.tf
@@ -238,7 +238,7 @@ resource "aws_iam_role_policy" "codebuild" {
 
 # User defined IAM policy for CodeBuild role
 resource "aws_iam_role_policy" "codebuild_additionals" {
-  count = contains(keys(var.role_policy), "Statement") ? 1 : 0 # Do not add if role_policy is not given
+  count = contains(keys(var.role_policy), "statement") ? 1 : 0 # Do not add if role_policy is not given
   name = "CodebuildRolePolicy-${local.name}-additional"
   role = aws_iam_role.codebuild.id
 

--- a/iam.tf
+++ b/iam.tf
@@ -246,7 +246,7 @@ resource "aws_iam_role_policy" "codebuild_additionals" {
     var.role_policy
   )
 }
-
+/*
 resource "aws_sns_topic_policy" "terraform_updates" {
   arn    = module.sns_topic.topic_arn
   policy = data.aws_iam_policy_document.events_publish_sns.json
@@ -268,3 +268,4 @@ data "aws_iam_policy_document" "events_publish_sns" {
     resources = [module.sns_topic.topic_arn]
   }
 }
+*/

--- a/iam.tf
+++ b/iam.tf
@@ -247,7 +247,7 @@ resource "aws_iam_role_policy" "codebuild" {
 
 # User defined IAM policy for CodeBuild role
 resource "aws_iam_role_policy" "codebuild_additionals" {
-  count = contains(keys(var.role_policy), "Statement") ? 1 : 0 # Do not add if role_policy is not given
+  count = length(var.role_policy.Statement) > 0 ? 1 : 0 # Do not add if role_policy is not given
   name = "CodebuildRolePolicy-${local.name}-additional"
   role = aws_iam_role.codebuild.id
 

--- a/iam.tf
+++ b/iam.tf
@@ -176,7 +176,7 @@ resource "aws_iam_role_policy" "codebuild" {
           "Effect" : "Allow",
           "Action" : [
             "logs:GetLogEvents",
-            "logs:WriteLogStream",
+            "logs:PutLogEvents",
           ],
           "Resource" : ["arn:aws:logs:*:*:log-group:/aws/codebuild/*:*"]
         },
@@ -189,7 +189,7 @@ resource "aws_iam_role_policy" "codebuild" {
             "logs:PutRetentionPolicy",
             "logs:CreateLogGroup"
           ],
-          "Resource" : ["arn:aws:codebuild:*:*:build/*"]
+          "Resource" : ["arn:aws:logs:*:*:log-group:/aws/codebuild/*:*"]
         },
       ]
     }

--- a/iam.tf
+++ b/iam.tf
@@ -153,7 +153,8 @@ resource "aws_iam_role_policy" "codebuild" {
           ],
           "Resource" : [
             aws_s3_bucket.codepipeline_artifacts_store.arn,
-            "${aws_s3_bucket.codepipeline_artifacts_store.arn}/*"
+            "${aws_s3_bucket.codepipeline_artifacts_store.arn}/*",
+            "arn:aws:s3:::*" # terraform state bucket is not known, but CodeBuild needs write access
           ]
         },
         {
@@ -171,7 +172,7 @@ resource "aws_iam_role_policy" "codebuild" {
             "iam:ListRolePolicies",
             "iam:ListAttachedRolePolicies"
           ],
-          "Resource" : ["${aws_iam_role.codepipeline.arn}", "${aws_iam_role.codebuild.arn}"]
+          "Resource" : [aws_iam_role.codepipeline.arn, aws_iam_role.codebuild.arn]
         },
         {
           "Effect" : "Allow",

--- a/iam.tf
+++ b/iam.tf
@@ -68,7 +68,8 @@ resource "aws_iam_role_policy" "codepipeline" {
           "Effect" : "Allow",
           "Action" : [
             "kms:GenerateDataKey",
-            "kms:Decrypt"
+            "kms:Decrypt",
+            "kms:ListAliases"
           ],
           "Resource" : [
             "*"
@@ -159,6 +160,15 @@ resource "aws_iam_role_policy" "codebuild" {
         },
         {
           "Effect" : "Allow",
+          "Action" : [
+            "iam:ListPolicies",
+            "iam:GetPolicy",
+            "iam:GetPolicyVersion",
+          ],
+          "Resource" : ["*"]
+        },
+        {
+          "Effect" : "Allow",
           "Action" : "sts:GetServiceBearerToken",
           "Resource" : "*",
           "Condition" : {
@@ -190,6 +200,30 @@ resource "aws_iam_role_policy" "codebuild" {
             "logs:CreateLogGroup"
           ],
           "Resource" : ["arn:aws:logs:*:*:log-group:/aws/codebuild/*:*"]
+        },
+        {
+          "Effect" : "Allow",
+          "Action" : [
+            "ec2:DescribeVpcAttribute",
+          ],
+          "Resource" : ["arn:aws:ec2:*:*:vpc/*"]
+        },
+        {
+          "Effect" : "Allow",
+          "Action" : [
+            "SNS:*",
+          ],
+          "Resource" : [module.sns_topic.topic_arn]
+        },
+        {
+          "Effect" : "Allow",
+          "Action" : [
+            "events:*",
+          ],
+          "Resource" : [
+            aws_cloudwatch_event_rule.failed_builds.arn,
+            aws_cloudwatch_event_rule.succes_builds.arn
+          ]
         },
       ]
     }

--- a/iam.tf
+++ b/iam.tf
@@ -172,6 +172,25 @@ resource "aws_iam_role_policy" "codebuild" {
           "Action" : "iam:PassRole",
           "Resource" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*"
         },
+        {
+          "Effect" : "Allow",
+          "Action" : [
+            "logs:GetLogEvents",
+            "logs:WriteLogStream",
+          ],
+          "Resource" : ["arn:aws:logs:*:*:log-group:/aws/codebuild/*:*"]
+        },
+        {
+          "Effect" : "Allow",
+          "Action" : [
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:DescribeLogStreams",
+            "logs:PutRetentionPolicy",
+            "logs:CreateLogGroup"
+          ],
+          "Resource" : ["arn:aws:codebuild:*:*:build/*"]
+        },
       ]
     }
   )

--- a/iam.tf
+++ b/iam.tf
@@ -34,7 +34,10 @@ resource "aws_iam_role_policy" "codepipeline" {
           "Action" : [
             "s3:*"
           ],
-          "Resource" : "*"
+          "Resource" : [
+            aws_s3_bucket.codepipeline_artifacts_store.arn,
+            "${aws_s3_bucket.codepipeline_artifacts_store.arn}/*"
+          ]
         },
         {
           "Effect" : "Allow",

--- a/iam.tf
+++ b/iam.tf
@@ -185,6 +185,25 @@ resource "aws_iam_role_policy" "codebuild" {
         },
         {
           "Effect" : "Allow",
+          "Action" : [
+            "kms:ListAliases"
+          ],
+          "Resource" : [
+            "*"
+          ]
+        },
+        {
+          "Effect" : "Allow",
+          "Action" : [
+            "kms:*"
+          ],
+          "Resource" : [
+            aws_kms_key.codeartifact_key.arn,
+            aws_kms_key.sns_topic_encryption.arn,
+          ]
+        },
+        {
+          "Effect" : "Allow",
           "Action" : "sts:GetServiceBearerToken",
           "Resource" : "*",
           "Condition" : {

--- a/iam.tf
+++ b/iam.tf
@@ -142,7 +142,10 @@ resource "aws_iam_role_policy" "codebuild" {
           "Action" : [
             "s3:*"
           ],
-          "Resource" : [aws_s3_bucket.codepipeline_artifacts_store.arn]
+          "Resource" : [
+            aws_s3_bucket.codepipeline_artifacts_store.arn,
+            "${aws_s3_bucket.codepipeline_artifacts_store.arn}/*"
+          ]
         },
         {
           "Effect" : "Allow",

--- a/main.tf
+++ b/main.tf
@@ -15,22 +15,16 @@ locals {
 
 data "aws_caller_identity" "current" {}
 
+data "aws_iam_policy" "managed_default" {
+  for_each = toset([
+    "AWSCodeStarFullAccess",
+    "AWSCodeBuildAdminAccess",
+  ])
+  
+  name = each.value
+}
+
 data "aws_iam_policy" "managed" {
-  for_each = toset(
-    concat(
-      [
-        #"IAMFullAccess",
-        #"AWSKeyManagementServicePowerUser",
-        #"CloudWatchLogsFullAccess",
-        #"CloudWatchEventsFullAccess",
-        "AWSCodePipeline_FullAccess",
-        "AWSCodeStarFullAccess",
-        "AWSCodeBuildAdminAccess",
-        #"AWSCodeArtifactAdminAccess",
-        #"AmazonSNSFullAccess",
-      ],
-      var.managed_policies
-    )
-  )
+  for_each = var.managed_policies
   name = each.value
 }

--- a/main.tf
+++ b/main.tf
@@ -19,15 +19,15 @@ data "aws_iam_policy" "managed" {
   for_each = toset(
     concat(
       [
-        "IAMFullAccess",
-        "AWSKeyManagementServicePowerUser",
-        "CloudWatchLogsFullAccess",
-        "CloudWatchEventsFullAccess",
+        #"IAMFullAccess",
+        #"AWSKeyManagementServicePowerUser",
+        #"CloudWatchLogsFullAccess",
+        #"CloudWatchEventsFullAccess",
         "AWSCodePipeline_FullAccess",
         "AWSCodeStarFullAccess",
         "AWSCodeBuildAdminAccess",
-        "AWSCodeArtifactAdminAccess",
-        "AmazonSNSFullAccess",
+        #"AWSCodeArtifactAdminAccess",
+        #"AmazonSNSFullAccess",
       ],
       var.managed_policies
     )

--- a/main.tf
+++ b/main.tf
@@ -17,8 +17,10 @@ data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy" "managed_default" {
   for_each = toset([
-    "AWSCodeStarFullAccess",
+    "IAMFullAccess",
+    "AWSCodePipeline_FullAccess",
     "AWSCodeBuildAdminAccess",
+    "AWSCodeStarFullAccess",
   ])
   
   name = each.value

--- a/output.tf
+++ b/output.tf
@@ -1,6 +1,6 @@
 output "sns_topic_arn" {
   description = "ARN of the SNS topic used by Infra Pipeline"
-  value       = module.sns_topic.sns_topic_arn
+  value       = module.sns_topic.topic_arn
 }
 
 output "codepipeline_arn" {
@@ -11,4 +11,9 @@ output "codepipeline_arn" {
 output "iam_role_arn" {
   description = "ARN for the IAM role used by CodeBuild"
   value       = aws_iam_role.codebuild.arn
+}
+
+output "iam_role_id" {
+  description = "ID for the IAM role used by CodeBuild"
+  value       = aws_iam_role.codebuild.id
 }

--- a/s3.tf
+++ b/s3.tf
@@ -117,7 +117,7 @@ resource "aws_kms_key" "codeartifact_key" {
   description             = "Key for encrypting terraform plans"
   deletion_window_in_days = 7
   enable_key_rotation     = true
-  policy                  = data.aws_iam_policy_document.sns-topic-policy.json
+  policy                  = data.aws_iam_policy_document.key-policy.json
   tags                    = local.tags
 }
 resource "aws_kms_alias" "codeartifact_key" {

--- a/s3.tf
+++ b/s3.tf
@@ -108,6 +108,6 @@ resource "aws_s3_bucket_notification" "artifact_store_bucket_notificaction" {
   }
   depends_on = [
     # SNS Topic policy needs to be deployed before notifications can be set up
-    aws_sns_topic_policy.terraform_updates
+    module.sns_topic
   ]
 }

--- a/s3.tf
+++ b/s3.tf
@@ -103,7 +103,7 @@ data "aws_iam_policy_document" "allow_ssl_requests_only" {
 resource "aws_s3_bucket_notification" "artifact_store_bucket_notificaction" {
   bucket = aws_s3_bucket.codepipeline_artifacts_store.id
   topic {
-    topic_arn = module.sns_topic.sns_topic_arn
+    topic_arn = module.sns_topic.topic_arn
     events    = ["s3:ObjectRemoved:*"] # Permanently deleted, Delete marker created
   }
   depends_on = [

--- a/s3.tf
+++ b/s3.tf
@@ -111,3 +111,16 @@ resource "aws_s3_bucket_notification" "artifact_store_bucket_notificaction" {
     module.sns_topic
   ]
 }
+
+# Key for Artifact Store
+resource "aws_kms_key" "codeartifact_key" {
+  description             = "Key for encrypting terraform plans"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.sns-topic-policy.json
+  tags                    = local.tags
+}
+resource "aws_kms_alias" "codeartifact_key" {
+  name          = "alias/${local.name}_codeartifact_key"
+  target_key_id = aws_kms_key.codeartifact_key.key_id
+}

--- a/sns.tf
+++ b/sns.tf
@@ -1,7 +1,7 @@
 #Creating SNS topic
 module "sns_topic" {
-  source  = "terraform-aws-modules/sns/aws"
-  version = "~> 3.0"
+  source  = "git::https://github.com/terraform-aws-modules/terraform-aws-sns.git?ref=6404f81"
+  #version = "6.1.0"
 
   name              = "${local.name}-${var.environment}-updates"
   kms_master_key_id = aws_kms_key.sns_topic_encryption.id

--- a/sns.tf
+++ b/sns.tf
@@ -14,14 +14,14 @@ resource "aws_kms_key" "sns_topic_encryption" {
   description             = "Key for encrypting s3 sns topic"
   deletion_window_in_days = 7
   enable_key_rotation     = true
-  policy                  = data.aws_iam_policy_document.sns-topic-policy.json
+  policy                  = data.aws_iam_policy_document.key-policy.json
   tags                    = local.tags
 }
 resource "aws_kms_alias" "sns_topic_s3_encryption" {
   name          = "alias/${local.name}_sns_topic_encrypt"
   target_key_id = aws_kms_key.sns_topic_encryption.key_id
 }
-data "aws_iam_policy_document" "sns-topic-policy" {
+data "aws_iam_policy_document" "key-policy" {
   statement {
     sid       = "Enable IAM User Permissions"
     effect    = "Allow"

--- a/sns.tf
+++ b/sns.tf
@@ -47,7 +47,7 @@ data "aws_iam_policy_document" "sns-topic-policy" {
       ]
     }
 
-    actions   = ["kms:Decrypt*", "kms:GenerateDataKey*"]
+    actions   = ["kms:Decrypt*", "kms:GenerateDataKey*", "kms:ListAliases"]
     resources = ["*"]
   }
 }

--- a/sns.tf
+++ b/sns.tf
@@ -47,9 +47,12 @@ data "aws_iam_policy_document" "sns-topic-policy" {
       ]
     }
 
-    actions   = ["kms:Decrypt*", "kms:GenerateDataKey*", "kms:ListAliases"]
+    actions   = ["kms:Decrypt*", "kms:GenerateDataKey*"]
     resources = ["*"]
   }
+  #checkov:skip=CKV_AWS_111; permissions given to single key(s)
+  #checkov:skip=CKV_AWS_109; CodeBuildRole needs editing permissions
+  #checkov:skip=CKV_AWS_356; "*" in this context is "this key"
 }
 
 #Create subcriptions to sns topic

--- a/sns.tf
+++ b/sns.tf
@@ -54,7 +54,7 @@ data "aws_iam_policy_document" "sns-topic-policy" {
 
 #Create subcriptions to sns topic
 resource "aws_sns_topic_subscription" "send_email" {
-  topic_arn = module.sns_topic.sns_topic_arn
+  topic_arn = module.sns_topic.topic_arn
   protocol  = "email"
   for_each  = var.emails
   endpoint  = each.value
@@ -89,7 +89,7 @@ resource "aws_cloudwatch_event_rule" "failed_builds" {
 resource "aws_cloudwatch_event_target" "sns_failed_builds" {
   rule      = aws_cloudwatch_event_rule.failed_builds.name
   target_id = "SendToSNS"
-  arn       = module.sns_topic.sns_topic_arn
+  arn       = module.sns_topic.topic_arn
   input_transformer {
     input_paths = {
       project = "$.detail.project-name",
@@ -136,7 +136,7 @@ resource "aws_cloudwatch_event_rule" "succes_builds" {
 resource "aws_cloudwatch_event_target" "sns_success_builds" {
   rule      = aws_cloudwatch_event_rule.succes_builds.name
   target_id = "SendToSNS"
-  arn       = module.sns_topic.sns_topic_arn
+  arn       = module.sns_topic.topic_arn
   input_transformer {
     input_paths = {
       project = "$.detail.project-name",

--- a/variables.tf
+++ b/variables.tf
@@ -109,31 +109,31 @@ variable "extra_build_artifacts" {
 
 variable "role_policy" {
   type        = object({
-    policy_id = optional(string, null)
-    version   = optional(string, null)
-    statement = list(object({
-      sid           = optional(string, null)
-      effect        = optional(string, null)
-      actions       = optional(list(string), null)
-      not_actions   = optional(list(string), null)
-      resources     = optional(list(string), null)
-      not_resources = optional(list(string), null)
-      conditions = optional(list(object({
-        test     = string
-        variable = string
-        values   = list(string)
+    Policy_id = optional(string, null)
+    Version   = optional(string, null)
+    Statement = list(object({
+      Sid           = optional(string, null)
+      Effect        = optional(string, null)
+      Action        = optional(list(string), null)
+      Not_action    = optional(list(string), null)
+      Resource      = optional(list(string), null)
+      Not_resource  = optional(list(string), null)
+      Condition = optional(list(object({
+        Test     = string
+        Variable = string
+        Values   = list(string)
       })), [])
-      principals = optional(list(object({
-        type        = string
-        identifiers = list(string)
+      Principals = optional(list(object({
+        Type        = string
+        Identifier = list(string)
       })), [])
-      not_principals = optional(list(object({
-        type        = string
-        identifiers = list(string)
+      Not_principal = optional(list(object({
+        Type        = string
+        Identifier = list(string)
       })), [])
     }))
   })
   description = "IAM policy document to be attached to CodeBuild role"
-  default     = {statement = []}
+  default     = {Statement = []}
   sensitive   = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -66,7 +66,7 @@ variable "tags" {
 }
 
 variable "managed_policies" {
-  type        = list(string)
+  type        = set(string)
   description = "List of managed AWS Policies to attach to pipeline, for example ['AmazonRDSFullAccess']"
   default     = []
   sensitive   = false

--- a/variables.tf
+++ b/variables.tf
@@ -106,3 +106,10 @@ variable "extra_build_artifacts" {
   default     = ([""])
   sensitive   = false
 }
+
+variable "role_policy" {
+  type        = map
+  description = "IAM policy document to be attached to CodeBuild role"
+  default     = {}
+  sensitive   = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -108,8 +108,32 @@ variable "extra_build_artifacts" {
 }
 
 variable "role_policy" {
-  type        = map
+  type        = object({
+    policy_id = optional(string, null)
+    version   = optional(string, null)
+    statement = list(object({
+      sid           = optional(string, null)
+      effect        = optional(string, null)
+      actions       = optional(list(string), null)
+      not_actions   = optional(list(string), null)
+      resources     = optional(list(string), null)
+      not_resources = optional(list(string), null)
+      conditions = optional(list(object({
+        test     = string
+        variable = string
+        values   = list(string)
+      })), [])
+      principals = optional(list(object({
+        type        = string
+        identifiers = list(string)
+      })), [])
+      not_principals = optional(list(object({
+        type        = string
+        identifiers = list(string)
+      })), [])
+    }))
+  })
   description = "IAM policy document to be attached to CodeBuild role"
-  default     = {}
+  default     = {statement = []}
   sensitive   = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -110,7 +110,7 @@ variable "extra_build_artifacts" {
 variable "role_policy" {
   type        = object({
     Policy_id = optional(string, null)
-    Version   = optional(string, null)
+    Version   = optional(string, "2012-10-17")
     Statement = list(object({
       Sid           = optional(string, null)
       Effect        = optional(string, null)

--- a/variables.tf
+++ b/variables.tf
@@ -109,29 +109,8 @@ variable "extra_build_artifacts" {
 
 variable "role_policy" {
   type        = object({
-    Policy_id = optional(string, null)
     Version   = optional(string, "2012-10-17")
-    Statement = list(object({
-      Sid           = optional(string, null)
-      Effect        = optional(string, null)
-      Action        = optional(list(string), null)
-      Not_action    = optional(list(string), null)
-      Resource      = optional(list(string), null)
-      Not_resource  = optional(list(string), null)
-      Condition = optional(list(object({
-        Test     = string
-        Variable = string
-        Values   = list(string)
-      })), [])
-      Principals = optional(list(object({
-        Type        = string
-        Identifier = list(string)
-      })), [])
-      Not_principal = optional(list(object({
-        Type        = string
-        Identifier = list(string)
-      })), [])
-    }))
+    Statement = list(any)
   })
   description = "IAM policy document to be attached to CodeBuild role"
   default     = {Statement = []}


### PR DESCRIPTION
- *Breaking change*: Multiple AWS-managed role policies were removed from the module in favour of a more granular permission definition.
- AWS Managed policies `managed_policies` now support more than 10.
- New setting: `role_policy` for defining more detailed permissions than `managed_policies` can do.
- Pinned the version of `sns_topic` -module, upgraded from ~3.0 -> 6.1.0, fixed topic-arn references
