### PR TITLE
feat: Possibility to customize what image CodeBuild uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Terraform module for defining AWS CodePipeline for applying infrastructure from 
 - Pipeline _without_ manual approval
 ```
 module "tf_infra_pipeline" {
-  source                = "git::https://github.com/Nets-Platform-Enablement/tf-module-aws-infra-pipeline?ref=v2.0.0"
+  source                = "git::https://github.com/Nets-Platform-Enablement/tf-module-aws-infra-pipeline?ref=v2.1.0"
   github_repository_id  = "Nets-Platform-Enablement/sample-project"
   environment           = "dev"
   require_manual_approval = false
@@ -22,13 +22,14 @@ data "aws_dynamodb_table" "tf_state" {
 - Pipeline with manual approval, failure and success reporting, custom variables file, .tfbackend-file, custom branch-name
 ```
 module "tf_infra_pipeline" {
-  source                = "git::https://github.com/Nets-Platform-Enablement/tf-module-aws-infra-pipeline?ref=v.2.0.0"
+  source                = "git::https://github.com/Nets-Platform-Enablement/tf-module-aws-infra-pipeline?ref=v.2.1.0"
   github_repository_id  = "Nets-Platform-Enablement/sample-project"
   branch_name           = "staging"
   environment           = "preprod"
   require_manual_approval = true
   tf_state_dynamodb_arn = data.aws_dynamodb_table.tf_state.arn
   variables_file        = "environment/prod.tfvars"
+  codebuild_image_id    = "aws/codebuild/amazonlinux2-aarch64-standard:3.0"
   tfbackend_file        = "environment/prod.s3.tfbackend"
   emails                = [ "first.last@nexigroup.com", "jane.doe@nexigroup.com" ]
   failure_notifications = "ENABLED"
@@ -66,6 +67,7 @@ data "aws_dynamodb_table" "tf_state" {
 | variables_file | File to provide terraform the variables with | string | "" | If not given, will automatically try to use `environments/{environment}.tfvars` |
 | tfbackend_file | File to provide terraform the backend config with | string | "" | Naming convension: {environment}.s3.tfbackend, see [HashiCorp documentation](https://developer.hashicorp.com/terraform/language/settings/backends/configuration#using-a-backend-block) |
 | terraform_version | The version of Terraform to use | string | "1.9.3" | |
+| codebuild_image_id | ID of the CodeBuild instance image | string | "aws/codebuild/standard:7.0" | [CodeBuild documentation](https://docs.aws.amazon.com/codebuild/latest/userguide/ec2-compute-images.html) |
 | tags | Map of Tag-Value -pairs to be added to all resources | map |  | `{ Tag: "Value", Cool: true }` |
 | managed_policies | List of AWS managed Policies to attach to pipeline | list(string) |  | example ['AmazonRDSFullAccess'] |
 | role_policy | A map describing IAM Role Policy, similar to [iam_role_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy). Module will format the value into json-string. | object({}) | {Statement = []} |  |

--- a/code-build.tf
+++ b/code-build.tf
@@ -1,11 +1,25 @@
 # CodeBuild
 
+# Key for CodeBuild projects
+resource "aws_kms_key" "codebuild" {
+  description             = "Key for encrypting CodeBuild projects"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.key-policy.json
+  tags                    = local.tags
+}
+resource "aws_kms_alias" "codebuild" {
+  name          = "alias/${local.name}_codebuild_key"
+  target_key_id = aws_kms_key.codebuild.key_id
+}
+
 #Validate terraform
 resource "aws_codebuild_project" "tflint" {
-  name         = "${local.name}-tflint"
-  description  = "Managed using Terraform"
-  service_role = aws_iam_role.codebuild.arn
-  tags         = local.tags
+  name            = "${local.name}-tflint"
+  description     = "Managed using Terraform"
+  service_role    = aws_iam_role.codebuild.arn
+  encryption_key  = aws_kms_key.codebuild.id
+  tags            = local.tags
   artifacts {
     type = "CODEPIPELINE"
   }
@@ -31,10 +45,11 @@ resource "aws_codebuild_project" "tflint" {
 
 #Do show and plan for dry run Terraform
 resource "aws_codebuild_project" "tf_plan" {
-  name         = "${local.name}-tf-plan"
-  description  = "Managed using Terraform"
-  service_role = aws_iam_role.codebuild.arn
-  tags         = local.tags
+  name            = "${local.name}-tf-plan"
+  description     = "Managed using Terraform"
+  service_role    = aws_iam_role.codebuild.arn
+  encryption_key  = aws_kms_key.codebuild.id
+  tags            = local.tags
   artifacts {
     type = "CODEPIPELINE"
   }
@@ -64,10 +79,11 @@ resource "aws_codebuild_project" "tf_plan" {
 }
 
 resource "aws_codebuild_project" "tf_apply" {
-  name         = "${local.name}-tf-apply"
-  description  = "Managed using Terraform"
-  service_role = aws_iam_role.codebuild.arn
-  tags         = local.tags
+  name            = "${local.name}-tf-apply"
+  description     = "Managed using Terraform"
+  service_role    = aws_iam_role.codebuild.arn
+  encryption_key  = aws_kms_key.codebuild.id
+  tags            = local.tags
 
   artifacts {
     type = "CODEPIPELINE"

--- a/code-build.tf
+++ b/code-build.tf
@@ -12,7 +12,7 @@ resource "aws_codebuild_project" "tflint" {
 
   environment {
     compute_type = "BUILD_GENERAL1_SMALL"
-    image        = "aws/codebuild/standard:7.0"
+    image        = var.codebuild_image_id
     type         = "LINUX_CONTAINER"
   }
 
@@ -41,7 +41,7 @@ resource "aws_codebuild_project" "tf_plan" {
 
   environment {
     compute_type = "BUILD_GENERAL1_SMALL"
-    image        = "aws/codebuild/standard:7.0"
+    image        = var.codebuild_image_id
     type         = "LINUX_CONTAINER"
     environment_variable {
       name  = "VAR_FILE"
@@ -75,7 +75,7 @@ resource "aws_codebuild_project" "tf_apply" {
 
   environment {
     compute_type = "BUILD_GENERAL1_SMALL"
-    image        = "aws/codebuild/standard:7.0"
+    image        = var.codebuild_image_id
     type         = "LINUX_CONTAINER"
     environment_variable {
       name  = "VAR_FILE"

--- a/variables.tf
+++ b/variables.tf
@@ -116,3 +116,9 @@ variable "role_policy" {
   default     = {Statement = []}
   sensitive   = false
 }
+
+variable "codebuild_image_id" {
+  type        = string
+  default     = "aws/codebuild/standard:7.0"
+  description = "ID of the CodeBuild instance image"
+}


### PR DESCRIPTION
New parameter `codebuild_image_id` refers to Image identifier in [AWS CodeBuild documentation](https://docs.aws.amazon.com/codebuild/latest/userguide/ec2-compute-images.html)

Default being current latest version of Ubuntu 22.04 `aws/codebuild/standard:7.0`, in the more complex example Amazon Linux 2023 is used.