### PR TITLE
feat: Removed S3 Bucket Notification, added bucket id to output

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -17,3 +17,8 @@ output "iam_role_id" {
   description = "ID for the IAM role used by CodeBuild"
   value       = aws_iam_role.codebuild.id
 }
+
+output "artifact_bucket_id" {
+  description = "Bucket used for store terraform plan"
+  value       = aws_s3_bucket.codepipeline_artifacts_store.id
+}

--- a/s3.tf
+++ b/s3.tf
@@ -99,19 +99,6 @@ data "aws_iam_policy_document" "allow_ssl_requests_only" {
   }
 }
 
-# S3 Event notificactions for bucket
-resource "aws_s3_bucket_notification" "artifact_store_bucket_notificaction" {
-  bucket = aws_s3_bucket.codepipeline_artifacts_store.id
-  topic {
-    topic_arn = module.sns_topic.topic_arn
-    events    = ["s3:ObjectRemoved:*"] # Permanently deleted, Delete marker created
-  }
-  depends_on = [
-    # SNS Topic policy needs to be deployed before notifications can be set up
-    module.sns_topic
-  ]
-}
-
 # Key for Artifact Store
 resource "aws_kms_key" "codeartifact_key" {
   description             = "Key for encrypting terraform plans"


### PR DESCRIPTION
New output: `artifact_bucket_id`, As bucket notifications were removed from the module, providing the bucket ID as output enables users to implement the notifications outside of the module (if they really need it)