### PR TITLE
Update code-build.tf

### DIFF
--- a/code-build.tf
+++ b/code-build.tf
@@ -18,7 +18,7 @@ resource "aws_codebuild_project" "tflint" {
   name            = "${local.name}-tflint"
   description     = "Managed using Terraform"
   service_role    = aws_iam_role.codebuild.arn
-  encryption_key  = aws_kms_key.codebuild.id
+  encryption_key  = aws_kms_key.codebuild.arn
   tags            = local.tags
   artifacts {
     type = "CODEPIPELINE"
@@ -48,7 +48,7 @@ resource "aws_codebuild_project" "tf_plan" {
   name            = "${local.name}-tf-plan"
   description     = "Managed using Terraform"
   service_role    = aws_iam_role.codebuild.arn
-  encryption_key  = aws_kms_key.codebuild.id
+  encryption_key  = aws_kms_key.codebuild.arn
   tags            = local.tags
   artifacts {
     type = "CODEPIPELINE"
@@ -82,7 +82,7 @@ resource "aws_codebuild_project" "tf_apply" {
   name            = "${local.name}-tf-apply"
   description     = "Managed using Terraform"
   service_role    = aws_iam_role.codebuild.arn
-  encryption_key  = aws_kms_key.codebuild.id
+  encryption_key  = aws_kms_key.codebuild.arn
   tags            = local.tags
 
   artifacts {


### PR DESCRIPTION
Use arn instead of id, so codebuild project won't be updated in place every run.