### PR TITLE
Feat/permissions update

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -123,13 +123,15 @@ resource "aws_iam_role" "codebuild" {
       ]
     }
   )
-  # Hard limit of 10 Managed policies
-  managed_policy_arns = [
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "codebuild" {
+  role_name   = aws_iam_role.codebuild.name
+  policy_arns = [
     for n in keys(data.aws_iam_policy.managed_default) : data.aws_iam_policy.managed_default[n].arn
   ]
 }
 
-# Attach overflow 
 resource "aws_iam_role_policy" "aws_managed" {
   for_each = tomap(data.aws_iam_policy.managed)
   name = "CodebuildRolePolicy-${each.key}"

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,13 @@
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=5.72.0"
+    }
+  }
+}
+
 locals {
   tags = merge(var.tags, {
     Module = "tf-module-aws-infra-pipeline"


### PR DESCRIPTION
Terraform has deprecated `aws_iam_role.managed_policies` property and suggest using `aws_iam_role_policy_attachments_exclusive` instead.

Also bumped aws-provider requirement to 5.72 or newer as aws_iam_role_policy_attachments_exclusive is not available on older provider versions