### PR TITLE
Fix/cloudwatch logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ module "tf_infra_pipeline" {
   emails                = [ "first.last@nexigroup.com", "jane.doe@nexigroup.com" ]
   failure_notifications = "ENABLED"
   success_notifications = "ENABLED"
+  logs_retention_time   = 30
   managed_policies      = ["AmazonRDSFullAccess", "AWSCodeCommitPowerUser"]
   role_policy           = {
     Statement = [
@@ -85,6 +86,7 @@ data "aws_dynamodb_table" "tf_state" {
 | extra_build_artifacts | filenames to be included for codepipeline apply step | set(string) | ([""]) |
 | enable_checkov | If checkov should be ran | boolean | false | Without `require_checkov_pass = true`, this will only log the findings | 
 | require_checkov_pass | Should failed checkov check prevent the changes from being applied | boolean | false | Requires `enable_checkov = true` to be effective | 
+| logs_retention_time | Time to retain the logs in days, allowed values: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365 and 0 | integer | 30 | 0 = never expire | 
 ## Notes
 
 - After initial deployment, the *CodeStar connection* needs to be [manually activated](https://eu-central-1.console.aws.amazon.com/codesuite/settings/connections), also ensure *AWS Connector for GitHub* has access to the repository you're deploying.
@@ -105,6 +107,8 @@ data "aws_dynamodb_table" "tf_state" {
 - terraform/tflint packages are stored in S3 bucket
 - Possibility to define version of tflint and checkov (default: 'latest')
 - fix: Deprecation fix for aws_iam_role.managed_policy_arns
+- fix: CodeBuild project log to a single CloudWatch Group `codebuild/{name}`
+  - New setting `logs_retention_time`
 
 
 ### v.2.1.0 Customizable build image

--- a/code-build.tf
+++ b/code-build.tf
@@ -18,6 +18,13 @@ resource "aws_kms_alias" "codebuild" {
   target_key_id = aws_kms_key.codebuild.key_id
 }
 
+# CloudWatch logs
+resource "aws_cloudwatch_log_group" "codebuild" {
+  name = local.name
+  tags = local.tags
+  retention_in_days = var.logs_retention_time
+}
+
 #Validate terraform
 resource "aws_codebuild_project" "tflint" {
   name            = "${local.name}-tflint"
@@ -33,6 +40,13 @@ resource "aws_codebuild_project" "tflint" {
     compute_type = "BUILD_GENERAL1_SMALL"
     image        = var.codebuild_image_id
     type         = "LINUX_CONTAINER"
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = aws_cloudwatch_log_group.codebuild.name
+      stream_name = "tflint"
+    }
   }
 
   source {

--- a/code-build.tf
+++ b/code-build.tf
@@ -20,7 +20,7 @@ resource "aws_kms_alias" "codebuild" {
 
 # CloudWatch logs
 resource "aws_cloudwatch_log_group" "codebuild" {
-  name = local.name
+  name = "codebuild/${local.name}"
   tags = local.tags
   retention_in_days = var.logs_retention_time
 }
@@ -77,6 +77,14 @@ resource "aws_codebuild_project" "checkov" {
     image        = "aws/codebuild/standard:7.0"
     type         = "LINUX_CONTAINER"
   }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = aws_cloudwatch_log_group.codebuild.name
+      stream_name = "checkov"
+    }
+  }
+
   source {
     type = "CODEPIPELINE"
     buildspec = templatefile(
@@ -101,6 +109,13 @@ resource "aws_codebuild_project" "tf_plan" {
   tags            = local.tags
   artifacts {
     type = "CODEPIPELINE"
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = aws_cloudwatch_log_group.codebuild.name
+      stream_name = "terraform-plan"
+    }
   }
 
   environment {
@@ -145,6 +160,13 @@ resource "aws_codebuild_project" "tf_apply" {
     environment_variable {
       name  = "VAR_FILE"
       value = local.tfvars
+    }
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = aws_cloudwatch_log_group.codebuild.name
+      stream_name = "terraform-apply"
     }
   }
 

--- a/code-pipeline-manual-approval.tf
+++ b/code-pipeline-manual-approval.tf
@@ -83,7 +83,7 @@ resource "aws_codepipeline" "terraform" {
       configuration = {
         NotificationArn    = module.sns_topic.topic_arn
         CustomData         = "This will deploy following ${local.name} IAC code changes into the ${var.environment} AWS environment"
-        ExternalEntityLink = "https://${var.aws_region}.console.aws.amazon.com/cloudwatch/home?region=${var.aws_region}#logsV2:log-groups/log-group/$252Faws$252Fcodebuild$252F${local.name}-tf-plan"
+        ExternalEntityLink = "https://${var.aws_region}.console.aws.amazon.com/cloudwatch/home?region=${var.aws_region}#logsV2:log-groups/log-group/${aws_cloudwatch_log_group.codebuild.name}/${aws_codebuild_project.tf_plan.name}"
       }
     }
   }

--- a/code-pipeline-manual-approval.tf
+++ b/code-pipeline-manual-approval.tf
@@ -83,7 +83,7 @@ resource "aws_codepipeline" "terraform" {
       configuration = {
         NotificationArn    = module.sns_topic.topic_arn
         CustomData         = "This will deploy following ${local.name} IAC code changes into the ${var.environment} AWS environment"
-        ExternalEntityLink = "https://${var.aws_region}.console.aws.amazon.com/cloudwatch/home?region=${var.aws_region}#logsV2:log-groups/log-group/${aws_cloudwatch_log_group.codebuild.name}/${aws_codebuild_project.tf_plan.name}"
+        ExternalEntityLink = "https://${var.aws_region}.console.aws.amazon.com/cloudwatch/home?region=${var.aws_region}#logsV2:log-groups/log-group/codebuild$252F${local.name}$3FlogStreamNameFilter$3Dterraform-plan"
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.6.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/variables.tf
+++ b/variables.tf
@@ -123,7 +123,7 @@ variable "success_notifications" {
 variable "logs_retention_time" {
   type = number
   default = 30
-  description = "Number of days to keep the logs, possibme values 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365 and 0 (never expire)"
+  description = "Number of days to keep the logs, possible values 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365 and 0 (never expire)"
   sensitive = false
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -120,6 +120,13 @@ variable "success_notifications" {
   sensitive   = false
 }
 
+variable "logs_retention_time" {
+  type = number
+  default = 30
+  description = "Number of days to keep the logs, possibme values 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365 and 0 (never expire)"
+  sensitive = false
+}
+
 variable "directory" {
   type        = string
   description = "Run TFlint / Terraform in this directory"


### PR DESCRIPTION
- New CloudWatch log group `codebuild/{repository-name}` for all CodeBuild projects to log to
- New variable: `logs_retention_time`  - how many days to retain the logs (default 30)