### PR TITLE
Feat/naming pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ data "aws_dynamodb_table" "tf_state" {
 ```
 module "tf_infra_pipeline" {
   source                = "git::https://github.com/Nets-Platform-Enablement/tf-module-aws-infra-pipeline?ref=v.2.2.0"
+  name                  = "example-pipeline"
   github_repository_id  = "Nets-Platform-Enablement/sample-project"
   branch_name           = "staging"
   environment           = "preprod"
@@ -64,6 +65,7 @@ data "aws_dynamodb_table" "tf_state" {
 | Name | Description | Type | Default | Notes |
 |------|-------------|------|---------|-------|
 | environment | Type of environment deploying to [test,dev,prod etc.] | string |  | Used in S3-bucket name so there might be collision |
+| name | Optional name for the pipeline, if not given, name is derived from the github repository name | string | "" | Alpha-numeric, dash (-) and underscore(_) allowed |
 | github_repository_id | ID of the terraform repository | string |  | `https://github.com/{this-part}.git` |
 | branch_name | Name of the branch to deploy | string | `main` |  |
 | tf_state_dynamodb_arn | ARN of the DynamoDB maintaining Terraform state | string |  |  |

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.6.2"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/main.tf
+++ b/main.tf
@@ -13,16 +13,13 @@ locals {
     Module = "tf-module-aws-infra-pipeline"
   })
 
+  repo_name = element(
+    split("/", var.github_repository_id),
+    length(split("/", var.github_repository_id)) - 1
+  )
   # If the 'name' is given, use it. Otherwise take the 'name' from github repository name
-  name = coalesce([
-    var.name,
-    element(
-      split("/", var.github_repository_id),
-      length(split("/", var.github_repository_id)) - 1
-    )
-  ])
-
-  tfvars            = var.variables_file == "" ? "environments/${var.environment}.tfvars" : var.variables_file
+  name      = coalesce(var.name, local.repo_name)
+  tfvars    = coalesce(var.variables_file, "environments/${var.environment}.tfvars")
 }
 
 data "aws_caller_identity" "current" {}

--- a/main.tf
+++ b/main.tf
@@ -13,11 +13,14 @@ locals {
     Module = "tf-module-aws-infra-pipeline"
   })
 
-  # Nets-Platform-Enamblement/Project-Name -> Project-Name
-  name = element(
-    split("/", var.github_repository_id),
-    length(split("/", var.github_repository_id)) - 1
-  )
+  # If the 'name' is given, use it. Otherwise take the 'name' from github repository name
+  name = coalesce([
+    var.name,
+    element(
+      split("/", var.github_repository_id),
+      length(split("/", var.github_repository_id)) - 1
+    )
+  ])
 
   tfvars            = var.variables_file == "" ? "environments/${var.environment}.tfvars" : var.variables_file
 }

--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,8 @@
+output "name" {
+  description = "Name of the pipeline"
+  value       = local.name
+}
+
 output "sns_topic_arn" {
   description = "ARN of the SNS topic used by Infra Pipeline"
   value       = module.sns_topic.topic_arn

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,18 @@ variable "aws_region" {
   sensitive   = false
 }
 
+variable "name" {
+  description = "Name of the pipeline, used naming resources it has"
+  default     = ""
+  type        = string
+  sensitive   = false
+  validation {
+    # regex(...) fails if it cannot find a match
+    condition     = can(regex("^[0-9A-Za-z_-]+$", var.name))
+    error_message = "For the name value only a-Z, 0-9, dash and underscore are allowed."
+  }
+}
+
 variable "require_manual_approval" {
   type        = bool
   description = "Whether or not a manual approval of changes is required before applying changes"


### PR DESCRIPTION
New parameter `name` 
- used as part of resources in the module
- easiest fix to running parallel pipelines from same github repo
- Optional, if not given the name is derived from github repository name as earlier