### PR TITLE
Feat/naming pipeline

### DIFF
--- a/code-build.tf
+++ b/code-build.tf
@@ -47,6 +47,10 @@ resource "aws_codebuild_project" "tflint" {
       }
     )
   }
+
+  lifecycle {
+    ignore_changes = [ name ]
+  }
 }
 
 resource "aws_codebuild_project" "checkov" {
@@ -75,6 +79,10 @@ resource "aws_codebuild_project" "checkov" {
         DIRECTORY       = var.directory
       }
     )
+  }
+
+  lifecycle {
+    ignore_changes = [ name ]
   }
 }
 
@@ -111,6 +119,10 @@ resource "aws_codebuild_project" "tf_plan" {
       }
     )
   }
+
+  lifecycle {
+    ignore_changes = [ name ]
+  }
 }
 
 resource "aws_codebuild_project" "tf_apply" {
@@ -144,5 +156,9 @@ resource "aws_codebuild_project" "tf_apply" {
         BACKENDFILE = var.tfbackend_file
       }
     )
+  }
+
+  lifecycle {
+    ignore_changes = [ name ]
   }
 }

--- a/code-pipeline-auto-approve.tf
+++ b/code-pipeline-auto-approve.tf
@@ -16,6 +16,11 @@ resource "aws_codepipeline" "terraform_without_approval" {
   name     = "${local.name}-${var.environment}-terraform-apply"
   role_arn = aws_iam_role.codepipeline.arn
   tags     = local.tags
+
+  lifecycle {
+    ignore_changes = [ name ]
+  }
+
   artifact_store {
     location = aws_s3_bucket.codepipeline_artifacts_store.bucket
     type     = "S3"

--- a/code-pipeline-manual-approval.tf
+++ b/code-pipeline-manual-approval.tf
@@ -1,8 +1,12 @@
 # CodePipeline
 
 resource "aws_codestarconnections_connection" "this" {
-  name          = "aws-github-connection"
+  name          = "github-connection-${local.name}"
   provider_type = "GitHub"
+  tags          = local.tags
+  lifecycle {
+    ignore_changes = [ name ]
+  }
 }
 
 resource "aws_codepipeline" "terraform" {

--- a/code-pipeline-manual-approval.tf
+++ b/code-pipeline-manual-approval.tf
@@ -10,6 +10,11 @@ resource "aws_codepipeline" "terraform" {
   name     = "${local.name}-${var.environment}-terraform-apply"
   role_arn = aws_iam_role.codepipeline.arn
   tags     = local.tags
+
+  lifecycle {
+    ignore_changes = [ name ]
+  }
+
   artifact_store {
     location = aws_s3_bucket.codepipeline_artifacts_store.bucket
     type     = "S3"

--- a/code-pipeline-manual-approval.tf
+++ b/code-pipeline-manual-approval.tf
@@ -1,7 +1,7 @@
 # CodePipeline
 
 resource "aws_codestarconnections_connection" "this" {
-  name          = "github-connection-${local.name}"
+  name          = substr("${local.name}-github", 0, 32)
   provider_type = "GitHub"
   tags          = local.tags
   lifecycle {

--- a/iam.tf
+++ b/iam.tf
@@ -105,6 +105,11 @@ resource "aws_iam_role_policy" "codepipeline" {
           "Effect" : "Allow",
           "Action" : "codestar-connections:UseConnection",
           "Resource" : "${aws_codestarconnections_connection.this.arn}"
+        },
+        {
+          "Effect" : "Allow",
+          "Action" : "codestar-connections:CreateConnection",
+          "Resource" : "arn:aws:codestar-connections:${var.aws_region}:${data.aws_caller_identity.current.account_id}:*"
         }
       ]
     }

--- a/iam.tf
+++ b/iam.tf
@@ -21,6 +21,7 @@ resource "aws_iam_role" "codepipeline" {
   )
 
   lifecycle {
+    ignore_changes = [ name_prefix ]
     create_before_destroy = true
   }
 }
@@ -31,6 +32,7 @@ resource "aws_iam_role_policy" "codepipeline" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [ name ]
   }
   policy = jsonencode(
     {
@@ -133,6 +135,7 @@ resource "aws_iam_role" "codebuild" {
   )
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [ name_prefix ]
   }
 }
 
@@ -149,12 +152,18 @@ resource "aws_iam_role_policy" "aws_managed" {
   role = aws_iam_role.codebuild.id
 
   policy = each.value.policy
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_iam_role_policy" "codebuild" {
   name = "CodebuildRolePolicy-${local.name}"
   role = aws_iam_role.codebuild.id
-
+  lifecycle {
+    create_before_destroy = true
+  }
   policy = jsonencode(
     {
       "Version" : "2012-10-17",

--- a/iam.tf
+++ b/iam.tf
@@ -296,12 +296,26 @@ resource "aws_iam_role_policy" "codebuild" {
           ]
         },
         {
+          "Sid" : "AllowEventTagging",
           "Effect" : "Allow",
           "Action" : [
-            "events:ListTagsForResource ",
+            "events:ListTagsForResource",
+            "events:TagResource",
           ],
-          "Resource" : ["arn:aws:events:*:${data.aws_caller_identity.current.account_id}:*"]
+          "Resource" : [
+            "arn:aws:events:*:${data.aws_caller_identity.current.account_id}:*"
+          ]
         },
+        {
+          Sid: "CodestarConnectionsManagement"
+          Effect : "Allow",
+          Action : [
+            "codestar-connections:*",
+          ],
+          Resource : [
+            "arn:aws:codestar-connections:*:${data.aws_caller_identity.current.account_id}:*"
+          ]
+        }
       ]
     }
   )

--- a/iam.tf
+++ b/iam.tf
@@ -108,7 +108,13 @@ resource "aws_iam_role_policy" "codepipeline" {
         },
         {
           "Effect" : "Allow",
-          "Action" : "codestar-connections:CreateConnection",
+          "Action" : [
+            "codestar-connections:CreateConnection",
+            "codestar-connections:DeleteConnection",
+            "codestar-connections:GetConnection",
+            "codestar-connections:DeleteConnection",
+            "codestar-connections:TagResource",
+          ]
           "Resource" : "arn:aws:codestar-connections:${var.aws_region}:${data.aws_caller_identity.current.account_id}:*"
         }
       ]

--- a/iam.tf
+++ b/iam.tf
@@ -19,12 +19,19 @@ resource "aws_iam_role" "codepipeline" {
       ]
     }
   )
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_iam_role_policy" "codepipeline" {
   role = aws_iam_role.codepipeline.id
   name = "CodepipelineRolePolicy-${local.name}"
 
+  lifecycle {
+    create_before_destroy = true
+  }
   policy = jsonencode(
     {
       "Version" : "2012-10-17",
@@ -124,6 +131,9 @@ resource "aws_iam_role" "codebuild" {
       ]
     }
   )
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_iam_role_policy_attachments_exclusive" "codebuild" {
@@ -277,4 +287,8 @@ resource "aws_iam_role_policy" "codebuild_additionals" {
   policy = jsonencode(
     var.role_policy
   )
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -155,6 +155,7 @@ resource "aws_iam_role_policy" "aws_managed" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [ name ]
   }
 }
 
@@ -163,6 +164,7 @@ resource "aws_iam_role_policy" "codebuild" {
   role = aws_iam_role.codebuild.id
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [ name ]
   }
   policy = jsonencode(
     {
@@ -299,5 +301,6 @@ resource "aws_iam_role_policy" "codebuild_additionals" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [ name ]
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -289,6 +289,13 @@ resource "aws_iam_role_policy" "codebuild" {
             aws_cloudwatch_event_rule.succes_builds.arn
           ]
         },
+        {
+          "Effect" : "Allow",
+          "Action" : [
+            "events:ListTagsForResource ",
+          ],
+          "Resource" : ["arn:aws:events:*:${data.aws_caller_identity.current.account_id}:*"]
+        },
       ]
     }
   )

--- a/s3-artifact-store.tf
+++ b/s3-artifact-store.tf
@@ -2,6 +2,10 @@ resource "aws_s3_bucket" "codepipeline_artifacts_store" {
   bucket        = lower("${local.name}-artifact-store-${var.environment}")
   tags          = local.tags
   force_destroy = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_s3_bucket_ownership_controls" "owner" {
@@ -110,4 +114,8 @@ resource "aws_kms_key" "codeartifact_key" {
 resource "aws_kms_alias" "codeartifact_key" {
   name          = "alias/${local.name}_codeartifact_key"
   target_key_id = aws_kms_key.codeartifact_key.key_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/s3-artifact-store.tf
+++ b/s3-artifact-store.tf
@@ -5,6 +5,7 @@ resource "aws_s3_bucket" "codepipeline_artifacts_store" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [ bucket ]
   }
 }
 

--- a/s3-installation-packages.tf
+++ b/s3-installation-packages.tf
@@ -53,7 +53,7 @@ data "http" "latest_release" {
   # Optional request headers
   request_headers = {
     Accept = "application/json"
-    User-Agent = "terraform/${local.terraform_version}"
+    User-Agent = "terraform"
   }
   lifecycle {
     postcondition {

--- a/s3-installation-packages.tf
+++ b/s3-installation-packages.tf
@@ -53,7 +53,7 @@ data "http" "latest_release" {
   # Optional request headers
   request_headers = {
     Accept = "application/json"
-    User-Agent = "terraform"
+    User-Agent = "terraform/${local.terraform_version}"
   }
   lifecycle {
     postcondition {

--- a/s3-installation-packages.tf
+++ b/s3-installation-packages.tf
@@ -55,6 +55,10 @@ data "http" "latest_release" {
     Accept = "application/json"
     User-Agent = "terraform"
   }
+  retry {
+    attempts = 3
+    min_delay_ms = 3000
+  }
   lifecycle {
     postcondition {
       condition     = contains([200, 201, 204, 304], self.status_code)

--- a/s3-installation-packages.tf
+++ b/s3-installation-packages.tf
@@ -49,6 +49,7 @@ data "http" "latest_release" {
   # Optional request headers
   request_headers = {
     Accept = "application/json"
+    User-Agent = "terraform"
   }
   lifecycle {
     postcondition {

--- a/s3-installation-packages.tf
+++ b/s3-installation-packages.tf
@@ -2,6 +2,10 @@ resource "aws_s3_bucket" "packages" {
   bucket        = lower("${local.name}-terraform-packages-${var.environment}")
   tags          = local.tags
   force_destroy = true
+
+  lifecycle {
+    ignore_changes = [ bucket ]
+  }
 }
 
 resource "aws_s3_bucket_ownership_controls" "packages" {

--- a/sns.tf
+++ b/sns.tf
@@ -94,6 +94,7 @@ resource "aws_cloudwatch_event_rule" "failed_builds" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [ name ]
   }
 }
 
@@ -145,6 +146,7 @@ resource "aws_cloudwatch_event_rule" "succes_builds" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [ name ]
   }
 }
 

--- a/sns.tf
+++ b/sns.tf
@@ -20,6 +20,10 @@ resource "aws_kms_key" "sns_topic_encryption" {
 resource "aws_kms_alias" "sns_topic_s3_encryption" {
   name          = "alias/${local.name}_sns_topic_encrypt"
   target_key_id = aws_kms_key.sns_topic_encryption.key_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 data "aws_iam_policy_document" "key-policy" {
   statement {
@@ -87,6 +91,10 @@ resource "aws_cloudwatch_event_rule" "failed_builds" {
     }
   })
   tags = local.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_cloudwatch_event_target" "sns_failed_builds" {
@@ -134,6 +142,10 @@ resource "aws_cloudwatch_event_rule" "succes_builds" {
     }
   })
   tags = local.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_cloudwatch_event_target" "sns_success_builds" {

--- a/variables.tf
+++ b/variables.tf
@@ -32,7 +32,7 @@ variable "name" {
   sensitive   = false
   validation {
     # regex(...) fails if it cannot find a match
-    condition     = can(regex("^[0-9A-Za-z_-]+$", var.name))
+    condition     = length(var.name) == 0 || can(regex("^[0-9A-Za-z_-]+$", var.name))
     error_message = "For the name value only a-Z, 0-9, dash and underscore are allowed."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "name" {
   type        = string
   sensitive   = false
   validation {
-    # regex(...) fails if it cannot find a match
+    # Either the name is empty or it contains only allowed characters
     condition     = length(var.name) == 0 || can(regex("^[0-9A-Za-z_-]+$", var.name))
     error_message = "For the name value only a-Z, 0-9, dash and underscore are allowed."
   }


### PR DESCRIPTION
Renaming a pipeline caused serious issues when running said pipeline. The name is used as part of resources belonging to the module, renaming caused many of them to be _replaced_ instead of updating in-place. This ended up deleting most of the resources mid-run.

This PR tries to make pipeline survive a renaming process by ignoring the name change on the resources that would require replacing. 