### PR TITLE
Add codebuild role arn to output

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -27,3 +27,8 @@ output "artifact_bucket_id" {
   description = "Bucket used for store terraform plan"
   value       = aws_s3_bucket.codepipeline_artifacts_store.id
 }
+
+output "codebuild_role_arn" {
+  description = "ARN for the CodeBuild IAM role"
+  value       = aws_iam_role.codebuild.arn
+}


### PR DESCRIPTION
This pull request adds a new output variable to the Terraform configuration, allowing consumers to access the ARN of the CodeBuild IAM role.

Outputs:

* Added a new output `codebuild_role_arn` to `output.tf` to expose the ARN for the CodeBuild IAM role.