### PR TITLE
Make tf_state_dynamodb_arn optional

### DIFF
--- a/code-pipeline-auto-approve.tf
+++ b/code-pipeline-auto-approve.tf
@@ -13,7 +13,7 @@ locals {
 
 resource "aws_codepipeline" "terraform_without_approval" {
   count    = var.require_manual_approval ? 0 : 1
-  name     = "${local.name}-${var.environment}-terraform-apply"
+  name     = substr("${local.name}-${var.environment}-terraform-apply", 0, 100)
   role_arn = aws_iam_role.codepipeline.arn
   tags     = local.tags
   artifact_store {

--- a/code-pipeline-manual-approval.tf
+++ b/code-pipeline-manual-approval.tf
@@ -7,7 +7,7 @@ resource "aws_codestarconnections_connection" "this" {
 
 resource "aws_codepipeline" "terraform" {
   count    = var.require_manual_approval ? 1 : 0
-  name     = "${local.name}-${var.environment}-terraform-apply"
+  name     = substr("${local.name}-${var.environment}-terraform-apply", 0, 100)
   role_arn = aws_iam_role.codepipeline.arn
   tags     = local.tags
   artifact_store {

--- a/iam.tf
+++ b/iam.tf
@@ -1,7 +1,7 @@
 #IAM for CodePipeline
 
 resource "aws_iam_role" "codepipeline" {
-  name_prefix = "CodepipelineRole-${local.name}"
+  name_prefix = substr("CodepipelineRole-${local.name}", 0, 38)
   description = "CodePipeline Service Role for ${local.name} - Managed by Terraform"
   tags        = local.tags
 
@@ -23,7 +23,7 @@ resource "aws_iam_role" "codepipeline" {
 
 resource "aws_iam_role_policy" "codepipeline" {
   role = aws_iam_role.codepipeline.id
-  name = "CodepipelineRolePolicy-${local.name}"
+  name = substr("CodepipelineRolePolicy-${local.name}", 0, 64)
 
   policy = jsonencode(
     {
@@ -105,8 +105,8 @@ resource "aws_iam_role_policy" "codepipeline" {
 #IAM for CodeBuild
 
 resource "aws_iam_role" "codebuild" {
-  name_prefix = "CodebuildRole-${local.name}"
-  description = "CodeBuild Service Role - Managed by Terraform"
+  name_prefix = substr("CodebuildRole-${local.name}", 0, 38)
+  description = "CodeBuild Service Role for ${local.name} - Managed by Terraform"
   tags        = local.tags
 
   assume_role_policy = jsonencode(
@@ -142,7 +142,7 @@ resource "aws_iam_role_policy" "aws_managed" {
 }
 
 resource "aws_iam_role_policy" "codebuild" {
-  name = "CodebuildRolePolicy-${local.name}"
+  name = substr("CodebuildRolePolicy-${local.name}", 0, 64)
   role = aws_iam_role.codebuild.id
 
   policy = jsonencode(

--- a/iam.tf
+++ b/iam.tf
@@ -148,7 +148,7 @@ resource "aws_iam_role_policy" "codebuild" {
   policy = jsonencode(
     {
       "Version" : "2012-10-17",
-      "Statement" : [
+      "Statement" : concat([
         {
           "Effect" : "Allow",
           "Action" : [
@@ -159,111 +159,111 @@ resource "aws_iam_role_policy" "codebuild" {
             "${aws_s3_bucket.codepipeline_artifacts_store.arn}/*",
             "arn:aws:s3:::*" # terraform state bucket is not known, but CodeBuild needs write access
           ]
-        },
-        {
+        }],
+        var.tf_state_dynamodb_arn != "" ? [{
           "Effect" : "Allow",
           "Action" : [
             "dynamodb:*"
           ],
           "Resource" : var.tf_state_dynamodb_arn
-        },
-        {
-          "Effect" : "Allow",
-          "Action" : [
-            "iam:GetRole",
-            "iam:GetRolePolicy",
-            "iam:ListRolePolicies",
-            "iam:ListAttachedRolePolicies"
-          ],
-          "Resource" : [aws_iam_role.codepipeline.arn, aws_iam_role.codebuild.arn]
-        },
-        {
-          "Effect" : "Allow",
-          "Action" : [
-            "iam:ListPolicies",
-            "iam:GetPolicy",
-            "iam:GetPolicyVersion",
-          ],
-          "Resource" : ["*"]
-        },
-        {
-          "Effect" : "Allow",
-          "Action" : [
-            "kms:ListAliases"
-          ],
-          "Resource" : [
-            "*"
-          ]
-        },
-        {
-          "Effect" : "Allow",
-          "Action" : [
-            "kms:*"
-          ],
-          "Resource" : [
-            aws_kms_key.codeartifact_key.arn,
-            aws_kms_key.sns_topic_encryption.arn,
-          ]
-        },
-        {
-          "Effect" : "Allow",
-          "Action" : "sts:GetServiceBearerToken",
-          "Resource" : "*",
-          "Condition" : {
-            "StringEquals" : {
-              "sts:AWSServiceName" : "codeartifact.amazonaws.com"
+        }] : [],
+        [
+          {
+            "Effect" : "Allow",
+            "Action" : [
+              "iam:GetRole",
+              "iam:GetRolePolicy",
+              "iam:ListRolePolicies",
+              "iam:ListAttachedRolePolicies"
+            ],
+            "Resource" : [aws_iam_role.codepipeline.arn, aws_iam_role.codebuild.arn]
+          },
+          {
+            "Effect" : "Allow",
+            "Action" : [
+              "iam:ListPolicies",
+              "iam:GetPolicy",
+              "iam:GetPolicyVersion",
+            ],
+            "Resource" : ["*"]
+          },
+          {
+            "Effect" : "Allow",
+            "Action" : [
+              "kms:ListAliases"
+            ],
+            "Resource" : [
+              "*"
+            ]
+          },
+          {
+            "Effect" : "Allow",
+            "Action" : [
+              "kms:*"
+            ],
+            "Resource" : [
+              aws_kms_key.codeartifact_key.arn,
+              aws_kms_key.sns_topic_encryption.arn,
+            ]
+          },
+          {
+            "Effect" : "Allow",
+            "Action" : "sts:GetServiceBearerToken",
+            "Resource" : "*",
+            "Condition" : {
+              "StringEquals" : {
+                "sts:AWSServiceName" : "codeartifact.amazonaws.com"
+              }
             }
-          }
-        },
-        {
-          "Effect" : "Allow",
-          "Action" : "iam:PassRole",
-          "Resource" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*"
-        },
-        {
-          "Effect" : "Allow",
-          "Action" : [
-            "logs:GetLogEvents",
-            "logs:PutLogEvents",
-          ],
-          "Resource" : ["arn:aws:logs:*:*:log-group:/aws/codebuild/*:*"]
-        },
-        {
-          "Effect" : "Allow",
-          "Action" : [
-            "logs:CreateLogGroup",
-            "logs:CreateLogStream",
-            "logs:DescribeLogStreams",
-            "logs:PutRetentionPolicy",
-            "logs:CreateLogGroup"
-          ],
-          "Resource" : ["arn:aws:logs:*:*:log-group:/aws/codebuild/*:*"]
-        },
-        {
-          "Effect" : "Allow",
-          "Action" : [
-            "ec2:DescribeVpcAttribute",
-          ],
-          "Resource" : ["arn:aws:ec2:*:*:vpc/*"]
-        },
-        {
-          "Effect" : "Allow",
-          "Action" : [
-            "SNS:*",
-          ],
-          "Resource" : [module.sns_topic.topic_arn]
-        },
-        {
-          "Effect" : "Allow",
-          "Action" : [
-            "events:*",
-          ],
-          "Resource" : [
-            aws_cloudwatch_event_rule.failed_builds.arn,
-            aws_cloudwatch_event_rule.succes_builds.arn
-          ]
-        },
-      ]
+          },
+          {
+            "Effect" : "Allow",
+            "Action" : "iam:PassRole",
+            "Resource" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*"
+          },
+          {
+            "Effect" : "Allow",
+            "Action" : [
+              "logs:GetLogEvents",
+              "logs:PutLogEvents",
+            ],
+            "Resource" : ["arn:aws:logs:*:*:log-group:/aws/codebuild/*:*"]
+          },
+          {
+            "Effect" : "Allow",
+            "Action" : [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:DescribeLogStreams",
+              "logs:PutRetentionPolicy",
+              "logs:CreateLogGroup"
+            ],
+            "Resource" : ["arn:aws:logs:*:*:log-group:/aws/codebuild/*:*"]
+          },
+          {
+            "Effect" : "Allow",
+            "Action" : [
+              "ec2:DescribeVpcAttribute",
+            ],
+            "Resource" : ["arn:aws:ec2:*:*:vpc/*"]
+          },
+          {
+            "Effect" : "Allow",
+            "Action" : [
+              "SNS:*",
+            ],
+            "Resource" : [module.sns_topic.topic_arn]
+          },
+          {
+            "Effect" : "Allow",
+            "Action" : [
+              "events:*",
+            ],
+            "Resource" : [
+              aws_cloudwatch_event_rule.failed_builds.arn,
+              aws_cloudwatch_event_rule.succes_builds.arn
+            ]
+      }])
     }
   )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,8 @@ variable "github_repository_id" {
 
 variable "tf_state_dynamodb_arn" {
   type        = string
-  description = "ARN of the DynamoDB maintaining Terraform state"
+  description = "ARN of the DynamoDB maintaining Terraform state (optional)"
+  default     = ""
   sensitive   = false
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,10 @@ variable "name" {
     condition     = length(var.name) == 0 || can(regex("^[0-9A-Za-z_-]+$", var.name))
     error_message = "For the name value only a-Z, 0-9, dash and underscore are allowed."
   }
+  validation {
+    condition     = length(var.name) == 0 || length(var.name) <= 38
+    error_message = "The name value must be 38 characters or less."
+  }
 }
 
 variable "require_manual_approval" {


### PR DESCRIPTION
This pull request updates the Terraform pipeline module to simplify state locking configuration and ensure resource names comply with AWS length limits. The main improvements are making DynamoDB-based state locking optional in favor of S3's native locking, clarifying documentation, and enforcing name length restrictions throughout the codebase.

**State Locking Improvements:**

* Made `tf_state_dynamodb_arn` optional, defaulting to an empty string, and updated documentation to recommend using S3's native `use_lockfile` feature for state locking instead of DynamoDB. This reduces infrastructure complexity and cost. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L72-R72) [[2]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL16-R17) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R93-R114)
* Updated example configurations and documentation in `README.md` to clarify when and how to use the `tf_state_dynamodb_arn` variable. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R36)

**Resource Name Length Enforcement:**

* Enforced maximum length constraints on IAM role and policy names using `substr` to prevent AWS resource creation failures due to name length limits. [[1]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecL4-R4) [[2]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecL26-R26) [[3]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecL108-R109) [[4]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecL145-R151)
* Added validation to the `name` variable to ensure it does not exceed 38 characters.
* Truncated CodePipeline resource names to a maximum of 100 characters to comply with AWS limits. [[1]](diffhunk://#diff-9db90344cbc7c1a53b78d44d85a61954aecb689fc9b5b8c978770546522c8b47L16-R16) [[2]](diffhunk://#diff-91aa84cea7ecc8c9d7a683847252506b3d03dffc91ceaf0c1874cdaeb8adb48aL10-R10)

**IAM Policy Conditional Logic:**

* Updated IAM policy for CodeBuild to only grant DynamoDB permissions if `tf_state_dynamodb_arn` is provided, making the policy more secure and flexible. [[1]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecL162-R170) [[2]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecL265-R266)