### PR TITLE
Add permissions for current patter of log group name

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -227,7 +227,10 @@ resource "aws_iam_role_policy" "codebuild" {
               "logs:GetLogEvents",
               "logs:PutLogEvents",
             ],
-            "Resource" : ["arn:aws:logs:*:*:log-group:/aws/codebuild/*:*"]
+            "Resource" : [
+              "arn:aws:logs:*:*:log-group:/aws/codebuild/*:*",
+              "arn:aws:logs:*:*:log-group:codebuild/*:*"
+            ]
           },
           {
             "Effect" : "Allow",
@@ -238,7 +241,10 @@ resource "aws_iam_role_policy" "codebuild" {
               "logs:PutRetentionPolicy",
               "logs:CreateLogGroup"
             ],
-            "Resource" : ["arn:aws:logs:*:*:log-group:/aws/codebuild/*:*"]
+            "Resource" : [
+              "arn:aws:logs:*:*:log-group:/aws/codebuild/*:*",
+              "arn:aws:logs:*:*:log-group:codebuild/*:*"
+            ]
           },
           {
             "Effect" : "Allow",


### PR DESCRIPTION
This pull request makes a small but important update to the IAM policy for the CodeBuild role. The change expands the set of CloudWatch log group ARNs that the role can access, ensuring compatibility with both `/aws/codebuild/*` and `codebuild/*` log group naming conventions.

IAM policy update:

* Updated the `Resource` entries in the CodeBuild IAM role policy to include both `arn:aws:logs:*:*:log-group:/aws/codebuild/*:*` and `arn:aws:logs:*:*:log-group:codebuild/*:*` for relevant CloudWatch Logs permissions. This broadens log group access and prevents potential permission issues with different log group naming patterns. [[1]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecL230-R233) [[2]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecL241-R247)