### PR TITLE
New option to create build instances inside VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ data "aws_dynamodb_table" "tf_state" {
 | tflint_version | The version of tflint to use | string | "latest" | Either semantic version number or "latest" |
 | checkov_version | The version of checkov to use | string | "latest" | Either semantic version number or "latest" |
 | codebuild_image_id | ID of the CodeBuild instance image | string | "aws/codebuild/standard:7.0" | [CodeBuild documentation](https://docs.aws.amazon.com/codebuild/latest/userguide/ec2-compute-images.html) |
+| vpc_id | VPC ID where CodeBuild projects will run (optional) | string | "" | If provided, CodeBuild instances will run inside the VPC in private networks |
+| subnet_ids | List of subnet IDs for CodeBuild projects (optional) | list(string) | [] | Use private subnets for security. Required if vpc_id is provided |
+| security_group_ids | List of security group IDs for CodeBuild projects (optional) | list(string) | [] | If not provided, a default security group with egress-only rules will be created |
 | tags | Map of Tag-Value -pairs to be added to all resources | map |  | `{ Tag: "Value", Cool: true }` |
 | managed_policies | List of AWS managed Policies to attach to pipeline | list(string) |  | example ['AmazonRDSFullAccess'] |
 | role_policy | A map describing IAM Role Policy, similar to [iam_role_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy). Module will format the value into json-string. | object({}) | {Statement = []} |  |
@@ -111,6 +114,43 @@ If you're currently using DynamoDB for state locking, you can migrate by:
 1. Adding `use_lockfile = true` to your `.tfbackend` file
 2. Removing or leaving empty the `tf_state_dynamodb_arn` variable in your module configuration
 3. The DynamoDB table can be removed after successful migration
+
+## VPC Configuration (Optional)
+
+You can optionally run CodeBuild instances inside a VPC in private networks for enhanced security. This is useful when your Terraform code needs to access resources in a private network or when you want to restrict outbound internet access.
+
+To enable VPC configuration, provide the VPC ID and subnet IDs:
+
+```hcl
+module "tf_infra_pipeline" {
+  source = "git::https://github.com/Nets-Platform-Enablement/tf-module-aws-infra-pipeline?ref=v.2.3.0"
+  
+  # ... other required variables ...
+  
+  # VPC Configuration (minimum required)
+  vpc_id     = "vpc-1234567890abcdef0"
+  subnet_ids = ["subnet-12345678", "subnet-87654321"]  # Use private subnets
+  
+  # Optional: Provide your own security groups
+  # security_group_ids = ["sg-12345678"]
+}
+```
+
+**Security Group Behavior:**
+- If you don't provide `security_group_ids`, the module will automatically create a default security group with:
+  - ✅ **Egress (outbound)**: Allow all traffic (required for downloading packages, accessing AWS APIs, etc.)
+  - ❌ **Ingress (inbound)**: No inbound rules (CodeBuild doesn't need incoming connections)
+- If you provide `security_group_ids`, your security groups will be used instead
+
+**Important considerations:**
+- Use **private subnets** for security best practices
+- Ensure your subnets have either:
+  - NAT Gateway configured for internet access (required for downloading Terraform, tflint, etc.)
+  - VPC endpoints for AWS services (S3, ECR, CloudWatch Logs, etc.)
+- If using custom security groups, ensure they allow outbound traffic to required services
+- The CodeBuild IAM role automatically receives the necessary EC2 network interface permissions when VPC is configured
+
+If you don't provide VPC configuration, CodeBuild instances will run in AWS-managed infrastructure with public internet access (default behavior).
 
 ## Notes
 

--- a/code-build.tf
+++ b/code-build.tf
@@ -3,7 +3,7 @@ locals {
   terraform_package = "${aws_s3_bucket.packages.bucket}/${local.packages.terraform.target}"
   tflint_package    = "${aws_s3_bucket.packages.bucket}/${local.packages.tflint.target}"
   # Use provided security groups or the default one we create
-  codebuild_security_group_ids = length(var.security_group_ids) > 0 ? var.security_group_ids : [aws_security_group.codebuild[0].id]
+  codebuild_security_group_ids = length(var.security_group_ids) > 0 ? var.security_group_ids : (var.vpc_id != "" ? [aws_security_group.codebuild[0].id] : [])
 }
 
 # Default security group for CodeBuild (only created if VPC is used and no security groups provided)

--- a/code-build.tf
+++ b/code-build.tf
@@ -2,6 +2,28 @@
 locals {
   terraform_package = "${aws_s3_bucket.packages.bucket}/${local.packages.terraform.target}"
   tflint_package    = "${aws_s3_bucket.packages.bucket}/${local.packages.tflint.target}"
+  # Use provided security groups or the default one we create
+  codebuild_security_group_ids = length(var.security_group_ids) > 0 ? var.security_group_ids : [aws_security_group.codebuild[0].id]
+}
+
+# Default security group for CodeBuild (only created if VPC is used and no security groups provided)
+resource "aws_security_group" "codebuild" {
+  count       = var.vpc_id != "" && length(var.security_group_ids) == 0 ? 1 : 0
+  name_prefix = "codebuild-${local.name}-"
+  description = "Security group for CodeBuild projects in ${local.name} pipeline"
+  vpc_id      = var.vpc_id
+  tags        = merge(local.tags, { Name = "codebuild-${local.name}" })
+
+  # Allow all outbound traffic (required for downloading packages, accessing AWS APIs, etc.)
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound traffic"
+  }
+
+  # No ingress rules - CodeBuild doesn't need inbound traffic
 }
 
 
@@ -42,6 +64,15 @@ resource "aws_codebuild_project" "tflint" {
     type         = "LINUX_CONTAINER"
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != "" ? [1] : []
+    content {
+      vpc_id             = var.vpc_id
+      subnets            = var.subnet_ids
+      security_group_ids = local.codebuild_security_group_ids
+    }
+  }
+
   logs_config {
     cloudwatch_logs {
       group_name  = aws_cloudwatch_log_group.codebuild.name
@@ -76,6 +107,15 @@ resource "aws_codebuild_project" "checkov" {
     compute_type = "BUILD_GENERAL1_SMALL"
     image        = "aws/codebuild/standard:7.0"
     type         = "LINUX_CONTAINER"
+  }
+
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != "" ? [1] : []
+    content {
+      vpc_id             = var.vpc_id
+      subnets            = var.subnet_ids
+      security_group_ids = local.codebuild_security_group_ids
+    }
   }
 
   logs_config {
@@ -128,6 +168,15 @@ resource "aws_codebuild_project" "tf_plan" {
     }
   }
 
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != "" ? [1] : []
+    content {
+      vpc_id             = var.vpc_id
+      subnets            = var.subnet_ids
+      security_group_ids = local.codebuild_security_group_ids
+    }
+  }
+
   source {
     type = "CODEPIPELINE"
     buildspec = templatefile(
@@ -160,6 +209,15 @@ resource "aws_codebuild_project" "tf_apply" {
     environment_variable {
       name  = "VAR_FILE"
       value = local.tfvars
+    }
+  }
+
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != "" ? [1] : []
+    content {
+      vpc_id             = var.vpc_id
+      subnets            = var.subnet_ids
+      security_group_ids = local.codebuild_security_group_ids
     }
   }
 

--- a/iam.tf
+++ b/iam.tf
@@ -252,13 +252,27 @@ resource "aws_iam_role_policy" "codebuild" {
               "ec2:DescribeVpcAttribute",
             ],
             "Resource" : ["arn:aws:ec2:*:*:vpc/*"]
-          },
-          {
-            "Effect" : "Allow",
-            "Action" : [
-              "SNS:*",
-            ],
-            "Resource" : [module.sns_topic.topic_arn]
+        }],
+        var.vpc_id != "" ? [{
+          "Effect" : "Allow",
+          "Action" : [
+            "ec2:CreateNetworkInterface",
+            "ec2:DescribeNetworkInterfaces",
+            "ec2:DeleteNetworkInterface",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeDhcpOptions",
+            "ec2:DescribeVpcs",
+            "ec2:CreateNetworkInterfacePermission"
+          ],
+          "Resource" : "*"
+        }] : [],
+        [{
+          "Effect" : "Allow",
+          "Action" : [
+            "SNS:*",
+          ],
+          "Resource" : [module.sns_topic.topic_arn]
           },
           {
             "Effect" : "Allow",

--- a/iam.tf
+++ b/iam.tf
@@ -253,20 +253,38 @@ resource "aws_iam_role_policy" "codebuild" {
             ],
             "Resource" : ["arn:aws:ec2:*:*:vpc/*"]
         }],
-        var.vpc_id != "" ? [{
-          "Effect" : "Allow",
-          "Action" : [
-            "ec2:CreateNetworkInterface",
-            "ec2:DescribeNetworkInterfaces",
-            "ec2:DeleteNetworkInterface",
-            "ec2:DescribeSubnets",
-            "ec2:DescribeSecurityGroups",
-            "ec2:DescribeDhcpOptions",
-            "ec2:DescribeVpcs",
-            "ec2:CreateNetworkInterfacePermission"
-          ],
-          "Resource" : "*"
-        }] : [],
+        var.vpc_id != "" ? [
+          {
+            "Effect" : "Allow",
+            "Action" : [
+              "ec2:CreateNetworkInterface"
+            ],
+            "Resource" : [
+              "arn:aws:ec2:*:*:network-interface/*",
+              "arn:aws:ec2:*:*:subnet/*",
+              "arn:aws:ec2:*:*:security-group/*"
+            ]
+          },
+          {
+            "Effect" : "Allow",
+            "Action" : [
+              "ec2:DeleteNetworkInterface",
+              "ec2:CreateNetworkInterfacePermission"
+            ],
+            "Resource" : "arn:aws:ec2:*:*:network-interface/*"
+          },
+          {
+            "Effect" : "Allow",
+            "Action" : [
+              "ec2:DescribeNetworkInterfaces",
+              "ec2:DescribeSubnets",
+              "ec2:DescribeSecurityGroups",
+              "ec2:DescribeDhcpOptions",
+              "ec2:DescribeVpcs"
+            ],
+            "Resource" : "*"
+          }
+        ] : [],
         [{
           "Effect" : "Allow",
           "Action" : [

--- a/variables.tf
+++ b/variables.tf
@@ -173,3 +173,24 @@ variable "codebuild_image_id" {
   default     = "aws/codebuild/standard:7.0"
   description = "ID of the CodeBuild instance image"
 }
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID where CodeBuild projects will run (optional). If provided, CodeBuild will run inside the VPC"
+  default     = ""
+  sensitive   = false
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "List of subnet IDs for CodeBuild projects (optional). Use private subnets for security. Required if vpc_id is provided"
+  default     = []
+  sensitive   = false
+}
+
+variable "security_group_ids" {
+  type        = list(string)
+  description = "List of security group IDs for CodeBuild projects (optional). If not provided and vpc_id is set, a default security group with egress-only rules will be created"
+  default     = []
+  sensitive   = false
+}


### PR DESCRIPTION
This pull request adds support for running CodeBuild projects inside a user-specified VPC for enhanced security and private networking. It introduces new variables for VPC configuration, updates documentation, and ensures that CodeBuild projects and their IAM roles are properly configured for VPC networking. The changes also provide sensible defaults for security groups and document best practices for secure configuration.

**VPC Support and Configuration**

* Added new input variables to `variables.tf` for `vpc_id`, `subnet_ids`, and `security_group_ids`, allowing users to specify VPC networking for CodeBuild projects.
* Updated `README.md` with documentation explaining how to enable VPC support, recommended security practices, and configuration examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R81-R83) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R118-R154)

**CodeBuild Project Updates**

* Modified all CodeBuild project resources in `code-build.tf` to conditionally include a `vpc_config` block when `vpc_id` is provided, wiring in subnets and security groups (either user-supplied or a default created by the module). [[1]](diffhunk://#diff-54728ebedf97b850ded3adc198652c733a938436f889a0117151db038f226b63R67-R75) [[2]](diffhunk://#diff-54728ebedf97b850ded3adc198652c733a938436f889a0117151db038f226b63R112-R120) [[3]](diffhunk://#diff-54728ebedf97b850ded3adc198652c733a938436f889a0117151db038f226b63R171-R179) [[4]](diffhunk://#diff-54728ebedf97b850ded3adc198652c733a938436f889a0117151db038f226b63R215-R223)
* Added logic and resource for creating a default security group with egress-only rules if no security groups are provided, ensuring secure outbound-only access for CodeBuild instances.

**IAM Role Permissions**

* Updated the CodeBuild IAM role policy in `iam.tf` to grant necessary EC2 permissions for network interface management when VPC configuration is enabled, ensuring CodeBuild can operate within the VPC.