### PR TITLE
Fix parenthesis

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -253,7 +253,7 @@ resource "aws_iam_role_policy" "codebuild" {
             ],
             "Resource" : ["arn:aws:ec2:*:*:vpc/*"]
         }],
-        var.vpc_id != "" ? [
+        (var.vpc_id != "" ? [
           {
             "Effect" : "Allow",
             "Action" : [
@@ -284,7 +284,7 @@ resource "aws_iam_role_policy" "codebuild" {
             ],
             "Resource" : "*"
           }
-        ] : [],
+        ] : []),
         [{
           "Effect" : "Allow",
           "Action" : [


### PR DESCRIPTION
This pull request makes a minor syntax update to the conditional logic used in the `aws_iam_role_policy` resource in `iam.tf`. The change improves the clarity and correctness of the conditional statement for including policy blocks based on the `vpc_id` variable.

* Refactored the conditional block in `aws_iam_role_policy` to use parentheses instead of brackets, ensuring proper evaluation and formatting of the policy statements when `var.vpc_id` is set. [[1]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecL256-R256) [[2]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecL287-R287)