### PR TITLE
Feat/run buildinstances inside vpc

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -148,7 +148,7 @@ resource "aws_iam_role_policy" "codebuild" {
   policy = jsonencode(
     {
       "Version" : "2012-10-17",
-      "Statement" : concat([
+      "Statement" : flatten([concat([
         {
           "Effect" : "Allow",
           "Action" : [
@@ -301,7 +301,7 @@ resource "aws_iam_role_policy" "codebuild" {
               aws_cloudwatch_event_rule.failed_builds.arn,
               aws_cloudwatch_event_rule.succes_builds.arn
             ]
-      }])
+      }])])
     }
   )
 }

--- a/iam.tf
+++ b/iam.tf
@@ -253,38 +253,36 @@ resource "aws_iam_role_policy" "codebuild" {
             ],
             "Resource" : ["arn:aws:ec2:*:*:vpc/*"]
         }],
-        (var.vpc_id != "" ? [
-          {
-            "Effect" : "Allow",
-            "Action" : [
-              "ec2:CreateNetworkInterface"
-            ],
-            "Resource" : [
-              "arn:aws:ec2:*:*:network-interface/*",
-              "arn:aws:ec2:*:*:subnet/*",
-              "arn:aws:ec2:*:*:security-group/*"
-            ]
-          },
-          {
-            "Effect" : "Allow",
-            "Action" : [
-              "ec2:DeleteNetworkInterface",
-              "ec2:CreateNetworkInterfacePermission"
-            ],
-            "Resource" : "arn:aws:ec2:*:*:network-interface/*"
-          },
-          {
-            "Effect" : "Allow",
-            "Action" : [
-              "ec2:DescribeNetworkInterfaces",
-              "ec2:DescribeSubnets",
-              "ec2:DescribeSecurityGroups",
-              "ec2:DescribeDhcpOptions",
-              "ec2:DescribeVpcs"
-            ],
-            "Resource" : "*"
-          }
-        ] : []),
+        var.vpc_id != "" ? [{
+          "Effect" : "Allow",
+          "Action" : [
+            "ec2:CreateNetworkInterface"
+          ],
+          "Resource" : [
+            "arn:aws:ec2:*:*:network-interface/*",
+            "arn:aws:ec2:*:*:subnet/*",
+            "arn:aws:ec2:*:*:security-group/*"
+          ]
+        }] : [],
+        var.vpc_id != "" ? [{
+          "Effect" : "Allow",
+          "Action" : [
+            "ec2:DeleteNetworkInterface",
+            "ec2:CreateNetworkInterfacePermission"
+          ],
+          "Resource" : "arn:aws:ec2:*:*:network-interface/*"
+        }] : [],
+        var.vpc_id != "" ? [{
+          "Effect" : "Allow",
+          "Action" : [
+            "ec2:DescribeNetworkInterfaces",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeDhcpOptions",
+            "ec2:DescribeVpcs"
+          ],
+          "Resource" : "*"
+        }] : [],
         [{
           "Effect" : "Allow",
           "Action" : [


### PR DESCRIPTION
This pull request refactors the way IAM policy statements are constructed for the `aws_iam_role_policy` resource in the `iam.tf` Terraform file. The main goal is to simplify and clarify the logic for conditionally including VPC-related permissions, making the code easier to read and maintain.

**IAM policy statement construction improvements:**

* Replaced nested `concat` and manual array concatenations with `flatten` and clearer conditional logic for adding VPC-related statements, reducing complexity and improving readability.
* Updated conditional blocks for VPC permissions to use more straightforward ternary logic, wrapping each conditional statement in its own array and flattening the result. This eliminates unnecessary array concatenations and makes the inclusion of statements more explicit. [[1]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecL256-R256) [[2]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecL267-R275) [[3]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecL286-R285)
* Fixed the final concatenation of statements to ensure all permissions are properly included in the policy document by correctly closing the array and flattening the result.