### PR TITLE
Add v3 optimized pipeline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ module "tf_infra_pipeline" {
   branch_name           = "staging"
   environment           = "preprod"
   require_manual_approval = true
+  pipeline_design       = "optimized"
   enable_checkov        = true
   require_checkov_pass  = true
+  enable_custom_codebuild_image = true
   terraform_version     = "1.9.8"
   tflint_version        = "0.53.0"
   checkov_version       = "3.2.281"
@@ -72,12 +74,16 @@ data "aws_dynamodb_table" "tf_state" {
 | tf_state_dynamodb_arn | ARN of the DynamoDB maintaining Terraform state (optional) | string | "" | Leave empty if not using DynamoDB for state locking |
 | aws_region | AWS region to deploy pipeline to | string | `eu-central-1` |  |
 | require_manual_approval | Whether or not a manual approval of changes is required before applying changes | bool | true |  |
+| pipeline_design | Pipeline design to use | string | `legacy` | `legacy` preserves the v2 pipeline shape for in-place upgrades. `optimized` enables the v3 optimized pipeline design |
 | variables_file | File to provide terraform the variables with | string | "" | If not given, will automatically try to use `environments/{environment}.tfvars` |
 | tfbackend_file | File to provide terraform the backend config with | string | "" | Naming convension: {environment}.s3.tfbackend, see [HashiCorp documentation](https://developer.hashicorp.com/terraform/language/settings/backends/configuration#using-a-backend-block) |
 | terraform_version | The version of Terraform to use | string | "latest" | Either semantic version number or "latest" |
 | tflint_version | The version of tflint to use | string | "latest" | Either semantic version number or "latest" |
 | checkov_version | The version of checkov to use | string | "latest" | Either semantic version number or "latest" |
 | codebuild_image_id | ID of the CodeBuild instance image | string | "aws/codebuild/standard:7.0" | [CodeBuild documentation](https://docs.aws.amazon.com/codebuild/latest/userguide/ec2-compute-images.html) |
+| enable_custom_codebuild_image | Whether to use a custom CodeBuild image in optimized pipeline mode | bool | false | If `custom_codebuild_image_uri` is empty, the module creates and updates a managed ECR image before running validate/plan/apply |
+| custom_codebuild_image_uri | Existing custom CodeBuild image URI to use in optimized pipeline mode | string | "" | Leave empty to let the module build a managed ECR image |
+| custom_codebuild_image_scan_on_push | Whether managed ECR images are scanned on push | bool | true | Only applies when the module creates the managed ECR image |
 | vpc_id | VPC ID where CodeBuild projects will run (optional) | string | "" | If provided, CodeBuild instances will run inside the VPC in private networks |
 | subnet_ids | List of subnet IDs for CodeBuild projects (optional) | list(string) | [] | Use private subnets for security. Required if vpc_id is provided |
 | security_group_ids | List of security group IDs for CodeBuild projects (optional) | list(string) | [] | If not provided, a default security group with egress-only rules will be created |
@@ -152,6 +158,60 @@ module "tf_infra_pipeline" {
 
 If you don't provide VPC configuration, CodeBuild instances will run in AWS-managed infrastructure with public internet access (default behavior).
 
+## v3 Pipeline Design and In-Place Upgrade
+
+Version 3 introduces an optimized pipeline design, but keeps the legacy v2 pipeline shape as the default. This lets existing users update the module version in place first and opt into the new design later.
+
+Recommended upgrade path:
+
+1. Update the module source/ref to v3 and leave `pipeline_design` unset, or set `pipeline_design = "legacy"` explicitly.
+2. Run `terraform plan` and confirm the existing pipeline remains on the legacy design.
+3. In a separate change, set `pipeline_design = "optimized"` after reviewing the planned resource changes.
+
+Legacy mode preserves the current behavior:
+- Separate CodeBuild projects for `tflint`, optional `checkov`, `terraform plan`, and `terraform apply`
+- Existing S3 package download flow for Terraform and tflint
+- Existing manual approval and auto-approve behavior
+
+Optimized mode changes the pipeline shape:
+- Runs `terraform init` once before approval
+- Runs `terraform validate`, `tflint`, and optional `checkov` in a consolidated `validate-plan` CodeBuild project
+- Produces both `thePlan.tfp` and a readable `plan.txt` artifact
+- Keeps manual approval tied to the saved plan artifact
+- Applies the exact saved plan artifact in the deploy stage
+
+To enable optimized mode with a module-managed ECR image:
+
+```hcl
+module "tf_infra_pipeline" {
+  source = "git::https://github.com/Nets-Platform-Enablement/tf-module-aws-infra-pipeline?ref=v3.0.0"
+
+  # ... other required variables ...
+
+  pipeline_design               = "optimized"
+  enable_checkov                = true
+  require_checkov_pass          = true
+  enable_custom_codebuild_image = true
+  terraform_version             = "1.9.8"
+  tflint_version                = "0.53.0"
+  checkov_version               = "3.2.281"
+}
+```
+
+When `enable_custom_codebuild_image = true` and `custom_codebuild_image_uri = ""`, the optimized pipeline adds a prepare stage that builds a CodeBuild runtime image and pushes it to ECR before validate/plan/apply runs. The image tag is derived from the configured Terraform, tflint, and Checkov versions, so changing a tool version creates a new deterministic image tag.
+
+If you already manage your own CodeBuild image, provide it directly:
+
+```hcl
+pipeline_design               = "optimized"
+enable_custom_codebuild_image = true
+custom_codebuild_image_uri    = "123456789012.dkr.ecr.eu-central-1.amazonaws.com/codebuild-terraform:tf-1-9-8-tflint-v0-53-0-checkov-3-2-281"
+```
+
+Rollback options:
+- Set `pipeline_design = "legacy"` to return to the legacy pipeline shape
+- Keep `pipeline_design = "optimized"` and pin `custom_codebuild_image_uri` to a previous known-good image tag
+
 ## Notes
 
 - Pipeline cannot do renaming (or adding `name`) to itself. Instead create a new instance of the module, apply changes and then remove the old instance. Also note the CodeStar connection note below.
@@ -176,8 +236,17 @@ If you don't provide VPC configuration, CodeBuild instances will run in AWS-mana
 | iam_role_id         | ID for the IAM role used by CodeBuild                    |
 | artifact_bucket_id  | ID of the bucket terraform plans are stored in           |
 | codebuild_role_arn  | ARN for the CodeBuild IAM role                           |
+| codebuild_image_repository_url | Repository URL for the managed custom CodeBuild image, when enabled |
+| codebuild_runtime_image | CodeBuild runtime image selected by the module |
 
 ## Releases
+
+### v.3.0.0 Optimized pipeline design
+- New setting: `pipeline_design`, defaulting to `legacy` for in-place upgrades from v2
+- New optimized pipeline design with consolidated validate/lint/security/plan CodeBuild project
+- New optional managed ECR CodeBuild image for Terraform, tflint and Checkov
+- Optimized mode keeps approval tied to the saved Terraform plan artifact
+- Legacy mode preserves the existing v2 pipeline shape and package download behavior
 
 ### v.2.2.2
 - New output: `codebuild_role_arn` (ARN for the CodeBuild IAM role)

--- a/README.md
+++ b/README.md
@@ -198,8 +198,7 @@ module "tf_infra_pipeline" {
 }
 ```
 
-When `enable_custom_codebuild_image = true` and `custom_codebuild_image_uri = ""`, the optimized pipeline adds a prepare stage that builds a CodeBuild runtime image and pushes it to ECR before validate/plan/apply runs. The image tag is derived from the configured Terraform, tflint, and Checkov versions, so changing a tool version creates a new deterministic image tag.
-
+When `enable_custom_codebuild_image = true` and `custom_codebuild_image_uri = ""`, the optimized pipeline adds a prepare stage that builds a CodeBuild runtime image and pushes it to ECR before validate/plan/apply runs. The image tag is derived from the configured Terraform, tflint, and Checkov versions; for deterministic tags, pin explicit versions (avoid `"latest"`).
 If you already manage your own CodeBuild image, provide it directly:
 
 ```hcl

--- a/code-build.tf
+++ b/code-build.tf
@@ -47,6 +47,72 @@ resource "aws_cloudwatch_log_group" "codebuild" {
   retention_in_days = var.logs_retention_time
 }
 
+resource "aws_codebuild_project" "codebuild_image" {
+  count          = local.manage_custom_codebuild_image ? 1 : 0
+  name           = "${local.name}-codebuild-image"
+  description    = "Managed using Terraform"
+  service_role   = aws_iam_role.codebuild.arn
+  encryption_key = aws_kms_key.codebuild.arn
+  tags           = local.tags
+
+  artifacts {
+    type = "CODEPIPELINE"
+  }
+
+  environment {
+    compute_type    = "BUILD_GENERAL1_SMALL"
+    image           = var.codebuild_image_id
+    privileged_mode = true
+    type            = "LINUX_CONTAINER"
+
+    environment_variable {
+      name  = "ECR_REPOSITORY_URI"
+      value = aws_ecr_repository.codebuild_image[0].repository_url
+    }
+
+    environment_variable {
+      name  = "IMAGE_TAG"
+      value = local.custom_codebuild_image_tag
+    }
+
+    environment_variable {
+      name  = "TERRAFORM_VERSION"
+      value = local.terraform_version
+    }
+
+    environment_variable {
+      name  = "TFLINT_VERSION"
+      value = local.tflint_version
+    }
+
+    environment_variable {
+      name  = "CHECKOV_VERSION"
+      value = var.checkov_version
+    }
+  }
+
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != "" ? [1] : []
+    content {
+      vpc_id             = var.vpc_id
+      subnets            = var.subnet_ids
+      security_group_ids = local.codebuild_security_group_ids
+    }
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = aws_cloudwatch_log_group.codebuild.name
+      stream_name = "codebuild-image"
+    }
+  }
+
+  source {
+    type      = "CODEPIPELINE"
+    buildspec = file("${path.module}/files/buildspec_codebuild_image.yml")
+  }
+}
+
 #Validate terraform
 resource "aws_codebuild_project" "tflint" {
   name           = "${local.name}-tflint"
@@ -60,7 +126,7 @@ resource "aws_codebuild_project" "tflint" {
 
   environment {
     compute_type = "BUILD_GENERAL1_SMALL"
-    image        = var.codebuild_image_id
+    image        = local.codebuild_runtime_image
     type         = "LINUX_CONTAINER"
   }
 
@@ -160,7 +226,7 @@ resource "aws_codebuild_project" "tf_plan" {
 
   environment {
     compute_type = "BUILD_GENERAL1_SMALL"
-    image        = var.codebuild_image_id
+    image        = local.codebuild_runtime_image
     type         = "LINUX_CONTAINER"
     environment_variable {
       name  = "VAR_FILE"
@@ -191,6 +257,64 @@ resource "aws_codebuild_project" "tf_plan" {
   }
 }
 
+resource "aws_codebuild_project" "validate_plan" {
+  count          = local.use_optimized_pipeline ? 1 : 0
+  name           = "${local.name}-validate-plan"
+  description    = "Managed using Terraform"
+  service_role   = aws_iam_role.codebuild.arn
+  encryption_key = aws_kms_key.codebuild.arn
+  tags           = local.tags
+
+  artifacts {
+    type = "CODEPIPELINE"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = local.codebuild_runtime_image
+    type         = "LINUX_CONTAINER"
+    environment_variable {
+      name  = "VAR_FILE"
+      value = local.tfvars
+    }
+  }
+
+  dynamic "vpc_config" {
+    for_each = var.vpc_id != "" ? [1] : []
+    content {
+      vpc_id             = var.vpc_id
+      subnets            = var.subnet_ids
+      security_group_ids = local.codebuild_security_group_ids
+    }
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name  = aws_cloudwatch_log_group.codebuild.name
+      stream_name = "validate-plan"
+    }
+  }
+
+  source {
+    type = "CODEPIPELINE"
+    buildspec = templatefile(
+      "${path.module}/files/buildspec_validate_plan.yml.tftpl",
+      {
+        TF_SOURCE       = local.terraform_package,
+        TFLINT_SOURCE   = local.tflint_package,
+        DIRECTORY       = var.directory,
+        EXTRA_FILES     = var.extra_build_artifacts,
+        BACKENDFILE     = var.tfbackend_file,
+        ENABLE_CHECKOV  = var.enable_checkov,
+        CHECKOV_VERSION = var.checkov_version,
+        LATEST_CHECKOV  = var.checkov_version == "latest",
+        SOFTFAIL        = !var.require_checkov_pass,
+        CUSTOM_IMAGE    = local.use_custom_codebuild_image
+      }
+    )
+  }
+}
+
 resource "aws_codebuild_project" "tf_apply" {
   name           = "${local.name}-tf-apply"
   description    = "Managed using Terraform"
@@ -204,7 +328,7 @@ resource "aws_codebuild_project" "tf_apply" {
 
   environment {
     compute_type = "BUILD_GENERAL1_SMALL"
-    image        = var.codebuild_image_id
+    image        = local.codebuild_runtime_image
     type         = "LINUX_CONTAINER"
     environment_variable {
       name  = "VAR_FILE"
@@ -231,11 +355,12 @@ resource "aws_codebuild_project" "tf_apply" {
   source {
     type = "CODEPIPELINE"
     buildspec = templatefile(
-      "${path.module}/files/${var.require_manual_approval ? "buildspec_tf_apply.yml.tftpl" : "buildspec_tf_apply_auto_approve.yml.tftpl"}",
+      "${path.module}/files/${var.require_manual_approval || local.use_optimized_pipeline ? "buildspec_tf_apply.yml.tftpl" : "buildspec_tf_apply_auto_approve.yml.tftpl"}",
       {
-        TF_SOURCE   = local.terraform_package,
-        DIRECTORY   = var.directory,
-        BACKENDFILE = var.tfbackend_file
+        TF_SOURCE    = local.terraform_package,
+        DIRECTORY    = var.directory,
+        BACKENDFILE  = var.tfbackend_file,
+        CUSTOM_IMAGE = local.use_custom_codebuild_image
       }
     )
   }

--- a/code-pipeline-auto-approve.tf
+++ b/code-pipeline-auto-approve.tf
@@ -12,7 +12,7 @@ locals {
 }
 
 resource "aws_codepipeline" "terraform_without_approval" {
-  count    = var.require_manual_approval ? 0 : 1
+  count    = !var.require_manual_approval && local.use_legacy_pipeline ? 1 : 0
   name     = substr("${local.name}-${var.environment}-terraform-apply", 0, 100)
   role_arn = aws_iam_role.codepipeline.arn
   tags     = local.tags
@@ -75,6 +75,92 @@ resource "aws_codepipeline" "terraform_without_approval" {
       version          = "1"
       configuration = {
         ProjectName = aws_codebuild_project.tf_apply.name
+      }
+    }
+  }
+}
+
+resource "aws_codepipeline" "terraform_without_approval_optimized" {
+  count    = !var.require_manual_approval && local.use_optimized_pipeline ? 1 : 0
+  name     = substr("${local.name}-${var.environment}-terraform-apply", 0, 100)
+  role_arn = aws_iam_role.codepipeline.arn
+  tags     = local.tags
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_artifacts_store.bucket
+    type     = "S3"
+    encryption_key {
+      type = "KMS"
+      id   = aws_kms_key.codeartifact_key.key_id
+    }
+  }
+  stage {
+    name = "Clone"
+    action {
+      name             = local.name
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeStarSourceConnection"
+      version          = "1"
+      output_artifacts = ["CodeWorkspace"]
+      configuration = {
+        ConnectionArn    = aws_codestarconnections_connection.this.arn
+        FullRepositoryId = var.github_repository_id
+        BranchName       = var.branch_name
+      }
+    }
+  }
+
+  dynamic "stage" {
+    for_each = local.manage_custom_codebuild_image ? [1] : []
+    content {
+      name = "Prepare-CodeBuild-Image"
+      action {
+        run_order        = 1
+        name             = "codebuild-image"
+        category         = "Build"
+        owner            = "AWS"
+        provider         = "CodeBuild"
+        input_artifacts  = ["CodeWorkspace"]
+        output_artifacts = []
+        version          = "1"
+        configuration = {
+          ProjectName = aws_codebuild_project.codebuild_image[0].name
+        }
+      }
+    }
+  }
+
+  stage {
+    name = "Validate-And-Plan"
+    action {
+      run_order        = 1
+      name             = "validate-plan"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["CodeWorkspace"]
+      output_artifacts = ["TerraformPlan"]
+      version          = "1"
+      configuration = {
+        ProjectName = aws_codebuild_project.validate_plan[0].name
+      }
+    }
+  }
+
+  stage {
+    name = "Deploy"
+    action {
+      run_order        = 1
+      name             = "terraform-apply"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["CodeWorkspace", "TerraformPlan"]
+      output_artifacts = []
+      version          = "1"
+      configuration = {
+        ProjectName   = aws_codebuild_project.tf_apply.name
+        PrimarySource = "CodeWorkspace"
       }
     }
   }

--- a/code-pipeline-manual-approval.tf
+++ b/code-pipeline-manual-approval.tf
@@ -6,7 +6,7 @@ resource "aws_codestarconnections_connection" "this" {
 }
 
 resource "aws_codepipeline" "terraform" {
-  count    = var.require_manual_approval ? 1 : 0
+  count    = var.require_manual_approval && local.use_legacy_pipeline ? 1 : 0
   name     = substr("${local.name}-${var.environment}-terraform-apply", 0, 100)
   role_arn = aws_iam_role.codepipeline.arn
   tags     = local.tags
@@ -84,6 +84,111 @@ resource "aws_codepipeline" "terraform" {
         NotificationArn    = module.sns_topic.topic_arn
         CustomData         = "This will deploy following ${local.name} IAC code changes into the ${var.environment} AWS environment"
         ExternalEntityLink = "https://${var.aws_region}.console.aws.amazon.com/cloudwatch/home?region=${var.aws_region}#logsV2:log-groups/log-group/codebuild$252F${local.name}$3FlogStreamNameFilter$3Dterraform-plan"
+      }
+    }
+  }
+
+  stage {
+    name = "Deploy"
+    action {
+      run_order        = 1
+      name             = "terraform-apply"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["CodeWorkspace", "TerraformPlan"]
+      output_artifacts = []
+      version          = "1"
+      configuration = {
+        ProjectName   = aws_codebuild_project.tf_apply.name
+        PrimarySource = "CodeWorkspace"
+      }
+    }
+  }
+}
+
+resource "aws_codepipeline" "terraform_optimized" {
+  count    = var.require_manual_approval && local.use_optimized_pipeline ? 1 : 0
+  name     = substr("${local.name}-${var.environment}-terraform-apply", 0, 100)
+  role_arn = aws_iam_role.codepipeline.arn
+  tags     = local.tags
+  artifact_store {
+    location = aws_s3_bucket.codepipeline_artifacts_store.bucket
+    type     = "S3"
+    encryption_key {
+      type = "KMS"
+      id   = aws_kms_key.codeartifact_key.key_id
+    }
+  }
+  stage {
+    name = "Clone"
+    action {
+      name             = local.name
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeStarSourceConnection"
+      version          = "1"
+      output_artifacts = ["CodeWorkspace"]
+      configuration = {
+        ConnectionArn    = aws_codestarconnections_connection.this.arn
+        FullRepositoryId = var.github_repository_id
+        BranchName       = var.branch_name
+      }
+    }
+  }
+
+  dynamic "stage" {
+    for_each = local.manage_custom_codebuild_image ? [1] : []
+    content {
+      name = "Prepare-CodeBuild-Image"
+      action {
+        run_order        = 1
+        name             = "codebuild-image"
+        category         = "Build"
+        owner            = "AWS"
+        provider         = "CodeBuild"
+        input_artifacts  = ["CodeWorkspace"]
+        output_artifacts = []
+        version          = "1"
+        configuration = {
+          ProjectName = aws_codebuild_project.codebuild_image[0].name
+        }
+      }
+    }
+  }
+
+  stage {
+    name = "Validate-And-Plan"
+    action {
+      run_order        = 1
+      name             = "validate-plan"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["CodeWorkspace"]
+      output_artifacts = ["TerraformPlan"]
+      version          = "1"
+
+      configuration = {
+        ProjectName = aws_codebuild_project.validate_plan[0].name
+      }
+    }
+  }
+
+  stage {
+    name = "Manual-Approval"
+    action {
+      run_order = 1
+      name      = "plan-approval"
+      category  = "Approval"
+      owner     = "AWS"
+      provider  = "Manual"
+      version   = "1"
+
+      configuration = {
+        NotificationArn    = module.sns_topic.topic_arn
+        CustomData         = "This will deploy following ${local.name} IAC code changes into the ${var.environment} AWS environment"
+        ExternalEntityLink = "https://${var.aws_region}.console.aws.amazon.com/cloudwatch/home?region=${var.aws_region}#logsV2:log-groups/log-group/codebuild$252F${local.name}$3FlogStreamNameFilter$3Dvalidate-plan"
       }
     }
   }

--- a/ecr-codebuild-image.tf
+++ b/ecr-codebuild-image.tf
@@ -1,0 +1,50 @@
+resource "aws_ecr_repository" "codebuild_image" {
+  count                = local.manage_custom_codebuild_image ? 1 : 0
+  name                 = lower("${local.name}-${var.environment}-codebuild-image")
+  image_tag_mutability = "MUTABLE"
+  tags                 = local.tags
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = aws_kms_key.codebuild.arn
+  }
+
+  image_scanning_configuration {
+    scan_on_push = var.custom_codebuild_image_scan_on_push
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "codebuild_image" {
+  count      = local.manage_custom_codebuild_image ? 1 : 0
+  repository = aws_ecr_repository.codebuild_image[0].name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep the latest 10 CodeBuild images"
+        selection = {
+          tagStatus   = "tagged"
+          countType   = "imageCountMoreThan"
+          countNumber = 10
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description  = "Delete untagged CodeBuild images after 7 days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 7
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/files/buildspec_codebuild_image.yml
+++ b/files/buildspec_codebuild_image.yml
@@ -1,0 +1,42 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - ECR_REGISTRY=${ECR_REPOSITORY_URI%/*}
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $ECR_REGISTRY
+      - IMAGE_URI="$ECR_REPOSITORY_URI:$IMAGE_TAG"
+  build:
+    commands:
+      - |
+        cat > Dockerfile <<'EOF'
+        FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+        ARG TERRAFORM_VERSION
+        ARG TFLINT_VERSION
+        ARG CHECKOV_VERSION
+
+        RUN dnf install -y curl findutils git gzip python3 python3-pip tar unzip which && \
+            dnf clean all
+
+        RUN curl -fsSL -o /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
+            unzip -o /tmp/terraform.zip -d /usr/local/bin && \
+            rm /tmp/terraform.zip
+
+        RUN curl -fsSL -o /tmp/tflint.zip "https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint_linux_amd64.zip" && \
+            unzip -o /tmp/tflint.zip -d /usr/local/bin && \
+            rm /tmp/tflint.zip
+
+        RUN if [ "$CHECKOV_VERSION" = "latest" ]; then \
+              pip3 install --no-cache-dir checkov; \
+            else \
+              pip3 install --no-cache-dir "checkov==$CHECKOV_VERSION"; \
+            fi
+
+        RUN terraform version && tflint --version && checkov --version
+        EOF
+      - docker build --build-arg TERRAFORM_VERSION=$TERRAFORM_VERSION --build-arg TFLINT_VERSION=$TFLINT_VERSION --build-arg CHECKOV_VERSION=$CHECKOV_VERSION -t $IMAGE_URI .
+  post_build:
+    commands:
+      - docker push $IMAGE_URI
+      - echo "Pushed $IMAGE_URI on `date`"

--- a/files/buildspec_tf_apply.yml.tftpl
+++ b/files/buildspec_tf_apply.yml.tftpl
@@ -4,9 +4,13 @@ phases:
 
   install:
     commands:
+%{ if !CUSTOM_IMAGE }
       - cd /usr/bin
       - aws s3 cp s3://${TF_SOURCE} terraform.zip
       - unzip -o terraform.zip
+%{ else }
+      - terraform version
+%{ endif }
 
   build:
     commands:
@@ -18,4 +22,6 @@ phases:
   post_build:
     commands:
       - echo "terraform apply completed on `date`"
+%{ if !CUSTOM_IMAGE }
       - rm /usr/bin/terraform.zip
+%{ endif }

--- a/files/buildspec_tf_apply_auto_approve.yml.tftpl
+++ b/files/buildspec_tf_apply_auto_approve.yml.tftpl
@@ -4,9 +4,13 @@ phases:
 
   install:
     commands:
+%{ if !CUSTOM_IMAGE }
       - cd /usr/bin
       - aws s3 cp s3://${TF_SOURCE} terraform.zip
       - unzip -o terraform.zip
+%{ else }
+      - terraform version
+%{ endif }
 
   build:
     commands:
@@ -18,4 +22,6 @@ phases:
   post_build:
     commands:
       - echo "terraform apply completed on `date`"
+%{ if !CUSTOM_IMAGE }
       - rm /usr/bin/terraform.zip
+%{ endif }

--- a/files/buildspec_validate_plan.yml.tftpl
+++ b/files/buildspec_validate_plan.yml.tftpl
@@ -1,0 +1,70 @@
+version: 0.2
+
+phases:
+
+  install:
+    commands:
+%{ if !CUSTOM_IMAGE }
+      - cd /usr/bin
+      - aws s3 cp s3://${TF_SOURCE} terraform.zip
+      - unzip -o terraform.zip
+      - aws s3 cp s3://${TFLINT_SOURCE} tflint.zip
+      - unzip -o tflint.zip -d /tmp/tflint
+      - sudo mkdir -p /usr/local/bin
+      - sudo install -c -v /tmp/tflint/tflint /usr/local/bin
+%{ if ENABLE_CHECKOV }
+      - pip3 install --upgrade pip
+      - pip3 install checkov%{ if !LATEST_CHECKOV }==${CHECKOV_VERSION}%{ endif }
+%{ endif }
+%{ else }
+      - terraform version
+      - tflint --version
+%{ if ENABLE_CHECKOV }
+      - checkov --version
+%{ endif }
+%{ endif }
+
+  build:
+    commands:
+      - cd "$CODEBUILD_SRC_DIR/${DIRECTORY}"
+      - terraform init %{ if BACKENDFILE != "" } -backend-config ${BACKENDFILE} %{ endif } -upgrade -no-color
+      - |
+        check_failed=0
+        terraform validate -no-color &
+        validate_pid=$!
+        (tflint --init && tflint) &
+        tflint_pid=$!
+%{ if ENABLE_CHECKOV }
+        (export CHECKOV_ENABLE_MODULES_FOREACH_HANDLING=false; checkov --directory ./ %{ if SOFTFAIL }--soft-fail%{ endif }) &
+        checkov_pid=$!
+%{ endif }
+        wait "$validate_pid" || check_failed=1
+        wait "$tflint_pid" || check_failed=1
+%{ if ENABLE_CHECKOV }
+        wait "$checkov_pid" || check_failed=1
+%{ endif }
+        if [ "$check_failed" -ne 0 ]; then exit 1; fi
+      - echo "Preview the changes that Terraform plans to make to your infrastructure on `date` that will be applied after approval"
+      - terraform plan --var-file $VAR_FILE -no-color -out thePlan.tfp
+      - terraform show -no-color thePlan.tfp > plan.txt
+      - echo "Terraform plan saved to thePlan.tfp and plan.txt"
+
+  post_build:
+    commands:
+      - echo "Validate and plan completed on `date`"
+%{ if !CUSTOM_IMAGE }
+      - rm /usr/bin/terraform.zip
+      - rm /usr/bin/tflint.zip
+%{ endif }
+
+artifacts:
+  files:
+    - thePlan.tfp
+    - plan.txt
+%{ if EXTRA_FILES != [""] }
+%{ for file in EXTRA_FILES ~}
+    - ${file}
+%{ endfor ~}
+%{ endif }
+  name: TerraformPlan
+  base-directory: ${DIRECTORY}

--- a/iam.tf
+++ b/iam.tf
@@ -85,12 +85,12 @@ resource "aws_iam_role_policy" "codepipeline" {
             "codebuild:StopBuild",
             "codebuild:BatchGetBuilds"
           ],
-          "Resource" : [
+          "Resource" : concat([
             aws_codebuild_project.tflint.arn,
             aws_codebuild_project.checkov.arn,
             aws_codebuild_project.tf_plan.arn,
             aws_codebuild_project.tf_apply.arn
-          ]
+          ], aws_codebuild_project.validate_plan[*].arn, aws_codebuild_project.codebuild_image[*].arn)
         },
         {
           "Effect" : "Allow",
@@ -282,6 +282,29 @@ resource "aws_iam_role_policy" "codebuild" {
             "ec2:DescribeVpcs"
           ],
           "Resource" : "*"
+        }] : [],
+        local.use_custom_codebuild_image ? [{
+          "Effect" : "Allow",
+          "Action" : [
+            "ecr:GetAuthorizationToken",
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:GetDownloadUrlForLayer",
+            "ecr:BatchGetImage"
+          ],
+          "Resource" : "*"
+        }] : [],
+        local.manage_custom_codebuild_image ? [{
+          "Effect" : "Allow",
+          "Action" : [
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:CompleteLayerUpload",
+            "ecr:DescribeImages",
+            "ecr:DescribeRepositories",
+            "ecr:InitiateLayerUpload",
+            "ecr:PutImage",
+            "ecr:UploadLayerPart"
+          ],
+          "Resource" : aws_ecr_repository.codebuild_image[0].arn
         }] : [],
         [{
           "Effect" : "Allow",

--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,24 @@ locals {
   # If the 'name' is given, use it. Otherwise take the 'name' from github repository name
   name   = coalesce(var.name, local.repo_name)
   tfvars = coalesce(var.variables_file, "environments/${var.environment}.tfvars")
+
+  use_legacy_pipeline    = var.pipeline_design == "legacy"
+  use_optimized_pipeline = var.pipeline_design == "optimized"
+  use_custom_codebuild_image = (
+    local.use_optimized_pipeline &&
+    var.enable_custom_codebuild_image
+  )
+  manage_custom_codebuild_image = local.use_custom_codebuild_image && var.custom_codebuild_image_uri == ""
+  custom_codebuild_image_tag = lower(join("-", [
+    "tf",
+    replace(local.terraform_version, ".", "-"),
+    "tflint",
+    replace(local.tflint_version, ".", "-"),
+    "checkov",
+    replace(var.checkov_version, ".", "-")
+  ]))
+  managed_codebuild_image_uri = local.manage_custom_codebuild_image ? "${aws_ecr_repository.codebuild_image[0].repository_url}:${local.custom_codebuild_image_tag}" : ""
+  codebuild_runtime_image     = local.use_custom_codebuild_image ? coalesce(var.custom_codebuild_image_uri, local.managed_codebuild_image_uri) : var.codebuild_image_id
 }
 
 data "aws_caller_identity" "current" {}

--- a/output.tf
+++ b/output.tf
@@ -10,7 +10,11 @@ output "sns_topic_arn" {
 
 output "codepipeline_arn" {
   description = "ARN of the CodePipeline"
-  value       = var.require_manual_approval ? aws_codepipeline.terraform[0].arn : aws_codepipeline.terraform_without_approval[0].arn
+  value = var.require_manual_approval ? (
+    local.use_optimized_pipeline ? aws_codepipeline.terraform_optimized[0].arn : aws_codepipeline.terraform[0].arn
+    ) : (
+    local.use_optimized_pipeline ? aws_codepipeline.terraform_without_approval_optimized[0].arn : aws_codepipeline.terraform_without_approval[0].arn
+  )
 }
 
 output "iam_role_arn" {
@@ -31,4 +35,14 @@ output "artifact_bucket_id" {
 output "codebuild_role_arn" {
   description = "ARN for the CodeBuild IAM role"
   value       = aws_iam_role.codebuild.arn
+}
+
+output "codebuild_image_repository_url" {
+  description = "Repository URL for the managed custom CodeBuild image"
+  value       = local.manage_custom_codebuild_image ? aws_ecr_repository.codebuild_image[0].repository_url : null
+}
+
+output "codebuild_runtime_image" {
+  description = "CodeBuild runtime image selected by the module"
+  value       = local.codebuild_runtime_image
 }

--- a/sns.tf
+++ b/sns.tf
@@ -79,11 +79,11 @@ resource "aws_cloudwatch_event_rule" "failed_builds" {
         "FAILED",
         "STOPPED",
       ],
-      "project-name" : [
+      "project-name" : concat([
         aws_codebuild_project.tflint.name,
         aws_codebuild_project.tf_plan.name,
         aws_codebuild_project.tf_apply.name,
-      ]
+      ], aws_codebuild_project.validate_plan[*].name)
     }
   })
   tags = local.tags

--- a/sns.tf
+++ b/sns.tf
@@ -81,9 +81,10 @@ resource "aws_cloudwatch_event_rule" "failed_builds" {
       ],
       "project-name" : concat([
         aws_codebuild_project.tflint.name,
+        aws_codebuild_project.checkov.name,
         aws_codebuild_project.tf_plan.name,
         aws_codebuild_project.tf_apply.name,
-      ], aws_codebuild_project.validate_plan[*].name)
+      ], aws_codebuild_project.validate_plan[*].name, aws_codebuild_project.codebuild_image[*].name)
     }
   })
   tags = local.tags

--- a/variables.tf
+++ b/variables.tf
@@ -190,6 +190,7 @@ variable "codebuild_image_id" {
 
 variable "enable_custom_codebuild_image" {
   type        = bool
+  nullable    = false
   default     = false
   description = "Whether or not to use a custom CodeBuild image in optimized pipeline mode"
   sensitive   = false

--- a/variables.tf
+++ b/variables.tf
@@ -195,6 +195,7 @@ variable "enable_custom_codebuild_image" {
 
 variable "custom_codebuild_image_uri" {
   type        = string
+  nullable    = false
   default     = ""
   description = "Custom CodeBuild image URI to use in optimized pipeline mode when enable_custom_codebuild_image is true"
   sensitive   = false

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,18 @@ variable "require_manual_approval" {
   sensitive   = false
 }
 
+variable "pipeline_design" {
+  type        = string
+  description = "Pipeline design to use. 'legacy' preserves the v2 pipeline shape, 'optimized' enables the v3 optimized pipeline design."
+  default     = "legacy"
+  sensitive   = false
+
+  validation {
+    condition     = contains(["legacy", "optimized"], var.pipeline_design)
+    error_message = "The pipeline_design value must be either 'legacy' or 'optimized'."
+  }
+}
+
 variable "enable_checkov" {
   type        = bool
   description = "If TRUE, pipeline will run checkov against codebase"
@@ -172,6 +184,27 @@ variable "codebuild_image_id" {
   type        = string
   default     = "aws/codebuild/standard:7.0"
   description = "ID of the CodeBuild instance image"
+}
+
+variable "enable_custom_codebuild_image" {
+  type        = bool
+  default     = false
+  description = "Whether or not to use a custom CodeBuild image in optimized pipeline mode"
+  sensitive   = false
+}
+
+variable "custom_codebuild_image_uri" {
+  type        = string
+  default     = ""
+  description = "Custom CodeBuild image URI to use in optimized pipeline mode when enable_custom_codebuild_image is true"
+  sensitive   = false
+}
+
+variable "custom_codebuild_image_scan_on_push" {
+  type        = bool
+  default     = true
+  description = "Whether or not the managed custom CodeBuild ECR repository scans images on push"
+  sensitive   = false
 }
 
 variable "vpc_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -51,9 +51,11 @@ variable "require_manual_approval" {
 
 variable "pipeline_design" {
   type        = string
+  nullable    = false
   description = "Pipeline design to use. 'legacy' preserves the v2 pipeline shape, 'optimized' enables the v3 optimized pipeline design."
   default     = "legacy"
   sensitive   = false
+
 
   validation {
     condition     = contains(["legacy", "optimized"], var.pipeline_design)


### PR DESCRIPTION
## Summary
- add v3-compatible pipeline_design switch with legacy as the default for in-place upgrades
- add optimized pipeline mode with consolidated validate/tflint/checkov/plan CodeBuild flow
- add optional managed ECR CodeBuild image build path for Terraform, tflint, and Checkov
- update apply buildspecs, IAM, SNS notifications, outputs, and README docs

## Validation
- terraform fmt -check
- terraform validate
- git diff --check

## AWS testing notes
- first test with pipeline_design unset or legacy to confirm existing v2-style consumers can update in place
- then test pipeline_design = optimized with enable_custom_codebuild_image = true to verify the ECR image prepare stage, validate-plan stage, manual approval, and saved-plan apply flow